### PR TITLE
Implement blog breadcrumbs

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,9 +1,11 @@
 import { renderBlock } from "@/app/components/blog/NotionRenderer";
+import { Breadcrumbs } from "@/app/components/blog/Breadcrumbs";
 import { getPublishedArticles, getPageContentByTitle } from "@/lib/notion";
 import { Badge } from "@/components/ui/badge";
 import { tagColors } from "@/lib/utils/tag_color";
 import { CalendarIcon, UserCircleIcon } from "lucide-react";
 import { BlockObjectResponse } from "@notionhq/client";
+import Script from "next/script";
 
 export default async function BlogDetailPage({
   params,
@@ -30,8 +32,43 @@ export default async function BlogDetailPage({
     throw new Error("記事内容の取得に失敗しました。");
   }
 
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? "";
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: `${baseUrl}/`,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Blog",
+        item: `${baseUrl}/blog`,
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: post.category,
+        item: `${baseUrl}/blog/category/${encodeURIComponent(post.category)}`,
+      },
+      {
+        "@type": "ListItem",
+        position: 4,
+        name: post.title,
+      },
+    ],
+  };
+
   return (
     <div className="max-w-3xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
+      <Breadcrumbs category={post.category} title={post.title} />
+      <Script id="breadcrumb-jsonld" type="application/ld+json">
+        {JSON.stringify(jsonLd)}
+      </Script>
       <header className="mb-8 border-b pb-6">
         <div className="flex justify-between">
           <h1 className="text-3xl font-bold text-gray-900">{post.title}</h1>

--- a/app/components/blog/Breadcrumbs.tsx
+++ b/app/components/blog/Breadcrumbs.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+
+interface BreadcrumbsProps {
+  category: string;
+  title: string;
+}
+
+export function Breadcrumbs({ category, title }: BreadcrumbsProps) {
+  return (
+    <Breadcrumb className="mb-4 px-4 sm:px-0 text-sm sm:text-base">
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link href="/">Home</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link href="/blog">Blog</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link href={`/blog/category/${encodeURIComponent(category)}`}>{category}</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>{title}</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}


### PR DESCRIPTION
## Summary
- add a Breadcrumbs component using shadcn ui
- integrate breadcrumbs and JSON-LD structured data on blog detail page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857fb29c0548328a94d2083aef5a5fd