### PR TITLE
Add tool distribution pages

### DIFF
--- a/app/api/tools/route.ts
+++ b/app/api/tools/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+import { getPublishedTools } from "@/lib/tool";
+
+export async function GET() {
+  const tools = await getPublishedTools();
+  return NextResponse.json(tools);
+}

--- a/app/components/HeaderTool.tsx
+++ b/app/components/HeaderTool.tsx
@@ -1,0 +1,109 @@
+"use client";
+import { useEffect, useState } from "react";
+import {
+  NavigationMenu,
+  NavigationMenuItem,
+  NavigationMenuList,
+} from "@/components/ui/navigation-menu";
+import Link from "next/link";
+import SimproSvg from "@/public/Simplo_gray_main_sub.svg";
+import Image from "next/image";
+import { Menu, X } from "lucide-react";
+
+const categories = ["Webツール", "Gas", "Excel VBA", "Executable File"];
+
+export function HeaderTool() {
+  const [hideHeader, setHideHeader] = useState(false);
+  const [lastScrollY, setLastScrollY] = useState(0);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const currentY = window.scrollY;
+      setHideHeader(currentY > lastScrollY && currentY > 80);
+      setLastScrollY(currentY);
+    };
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [lastScrollY]);
+
+  return (
+    <header
+      className={`fixed top-0 left-0 w-full z-50 transition-transform duration-300 ${
+        hideHeader ? "-translate-y-full" : "translate-y-0"
+      }`}
+    >
+      <div className="bg-white shadow">
+        <div className="container mx-auto flex items-center justify-between px-4 py-4">
+          <div className="flex items-center gap-2">
+            <Link href="/" className="text-xl font-bold">
+              <Image src={SimproSvg} alt="Simpro Logo" width={100} height={40} priority />
+            </Link>
+            <p className="text-black text-xl"> - Tools</p>
+          </div>
+          <NavigationMenu className="hidden md:block">
+            <NavigationMenuList className="space-x-6">
+              <NavigationMenuItem>
+                <Link href="#top" className="hover:underline">
+                  TOP
+                </Link>
+              </NavigationMenuItem>
+              <NavigationMenuItem>
+                <Link href="#category" className="hover:underline">
+                  カテゴリ
+                </Link>
+              </NavigationMenuItem>
+              <NavigationMenuItem>
+                <Link href="#login" className="hover:underline">
+                  ログイン
+                </Link>
+              </NavigationMenuItem>
+            </NavigationMenuList>
+          </NavigationMenu>
+          <div className="md:hidden">
+            <button onClick={() => setMenuOpen(!menuOpen)} className="transition-transform duration-200">
+              {menuOpen ? <X size={24} /> : <Menu size={24} />}
+            </button>
+          </div>
+        </div>
+        <div
+          className={`md:hidden overflow-hidden transition-all duration-300 ease-in-out ${
+            menuOpen ? "max-h-60 opacity-100 py-4" : "max-h-0 opacity-0 py-0"
+          } bg-white px-6`}
+        >
+          <ul className="space-y-4 text-base">
+            <li>
+              <Link href="#top" onClick={() => setMenuOpen(false)}>
+                サービス
+              </Link>
+            </li>
+            <li>
+              <Link href="#projects" onClick={() => setMenuOpen(false)}>
+                実績
+              </Link>
+            </li>
+            <li>
+              <Link href="#contact" onClick={() => setMenuOpen(false)}>
+                お問い合わせ
+              </Link>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <nav className="bg-neutral-800 py-3">
+        <ul className="flex justify-center gap-8">
+          {categories.map((category) => (
+            <li key={category}>
+              <Link
+                href={`/tool/category/${encodeURIComponent(category)}`}
+                className="text-white text-lg tracking-wide hover:underline transition"
+              >
+                {category}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </header>
+  );
+}

--- a/app/components/ToolIntroSection.tsx
+++ b/app/components/ToolIntroSection.tsx
@@ -112,7 +112,7 @@ export function ToolIntroSection() {
               transition={{ duration: 1.6, ease: "easeOut" }}
               viewport={{ once: true }}
             >
-              <Link href={`/tools/${tool.slug}`}>
+              <Link href={`/tool/${tool.slug}`}>
                 <div className="w-full h-40 relative">
                   <Image
                     src={tool.image}
@@ -137,7 +137,7 @@ export function ToolIntroSection() {
 
         {/* CTA */}
         <Link
-          href="/tools"
+          href="/tool"
           className="inline-block mt-6 bg-green-600 text-white px-6 py-2 rounded-xl font-medium hover:bg-green-700 transition"
         >
           ツール一覧を見る

--- a/app/components/tool/ToolBreadcrumbs.tsx
+++ b/app/components/tool/ToolBreadcrumbs.tsx
@@ -1,0 +1,69 @@
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+
+interface BreadcrumbsProps {
+  category?: string;
+  title?: string;
+}
+
+type Crumb = {
+  name: string;
+  href?: string;
+};
+
+export function ToolBreadcrumbs({ category, title }: BreadcrumbsProps) {
+  const items: Crumb[] = [
+    { name: "Home", href: "/" },
+    { name: "Tools", href: "/tool" },
+  ];
+
+  if (category) {
+    items.push({
+      name: category,
+      href: `/tool/category/${encodeURIComponent(category)}`,
+    });
+  }
+
+  if (title) {
+    items.push({ name: title });
+  }
+
+  return (
+    <Breadcrumb className="mb-6 px-4 sm:px-0 text-sm text-muted-foreground">
+      <BreadcrumbList className="flex flex-wrap items-center gap-x-1 gap-y-1 sm:gap-x-2">
+        {items.map((item, index) => {
+          const isLast = index === items.length - 1;
+
+          return (
+            <div key={index} className="flex items-center">
+              <BreadcrumbItem>
+                {item.href && !isLast ? (
+                  <BreadcrumbLink asChild>
+                    <Link href={item.href} className="hover:text-primary hover:underline transition-colors capitalize">
+                      {item.name}
+                    </Link>
+                  </BreadcrumbLink>
+                ) : (
+                  <BreadcrumbPage className="font-medium capitalize">{item.name}</BreadcrumbPage>
+                )}
+              </BreadcrumbItem>
+              {!isLast && (
+                <BreadcrumbSeparator>
+                  <ChevronRight className="w-4 h-4 text-gray-400" />
+                </BreadcrumbSeparator>
+              )}
+            </div>
+          );
+        })}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/app/components/tool/ToolCard.tsx
+++ b/app/components/tool/ToolCard.tsx
@@ -31,7 +31,7 @@ export function ToolCard({ tool }: { tool: Tool }) {
           ))}
         </div>
         <Link
-          href={`/tools/${tool.slug}`}
+          href={`/tool/${tool.slug}`}
           className="inline-block mt-2 text-sm text-blue-600 hover:underline"
         >
           ダウンロード

--- a/app/tool/[slug]/page.tsx
+++ b/app/tool/[slug]/page.tsx
@@ -1,0 +1,69 @@
+import { ToolBreadcrumbs } from "@/app/components/tool/ToolBreadcrumbs";
+import { generateBreadcrumbJsonLd } from "@/lib/seo/breadcrumb";
+import { getToolBySlug } from "@/lib/tool";
+import { Badge } from "@/components/ui/badge";
+import { tagColors } from "@/lib/utils/tag_color";
+import { CalendarIcon, UserCircleIcon } from "lucide-react";
+import Image from "next/image";
+import Script from "next/script";
+import { notFound } from "next/navigation";
+
+export default async function ToolDetailPage({ params }: { params: { slug: string } }) {
+  const slug = decodeURIComponent(params.slug);
+  const tool = await getToolBySlug(slug);
+
+  if (!tool) {
+    notFound();
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? "";
+  const breadcrumbItems = [
+    { name: "Home", url: `${baseUrl}/` },
+    { name: "Tools", url: `${baseUrl}/tool` },
+    { name: tool.category, url: `${baseUrl}/tool/category/${encodeURIComponent(tool.category)}` },
+    { name: tool.title },
+  ];
+  const jsonLd = generateBreadcrumbJsonLd(breadcrumbItems);
+
+  return (
+    <div className="px-20 py-4 mt-8">
+      <ToolBreadcrumbs category={tool.category} title={tool.title} />
+      <div className="max-w-3xl mx-auto py-12">
+        <Script id="breadcrumb-tool-jsonld" type="application/ld+json">
+          {JSON.stringify(jsonLd)}
+        </Script>
+        <header className="mb-8 border-b pb-6">
+          <div className="flex justify-between">
+            <h1 className="text-3xl font-bold text-gray-900">{tool.title}</h1>
+            <div className="flex items-center gap-2 text-sm text-gray-600">
+              <CalendarIcon className="w-4 h-4" />
+              <p>{tool.date}</p>
+            </div>
+          </div>
+          <div className="flex items-center justify-between flex-wrap gap-4 text-sm text-gray-600 mt-2">
+            <div className="flex items-center gap-2 p-3">
+              <UserCircleIcon className="w-4 h-4" />
+              <span>{tool.author}</span>
+            </div>
+          </div>
+          <div className="mt-1 text-sm text-gray-500 flex flex-wrap items-center gap-2">
+            <div className="flex flex-wrap gap-1">
+              {tool.tags.map((tag) => (
+                <Badge
+                  key={tag}
+                  className={`rounded-full px-3 py-1 text-xs font-medium ${tagColors[tag] || tagColors.default}`}
+                >
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        </header>
+        <div className="mb-8">
+          <Image src={tool.imageUrl} alt={tool.title} width={600} height={400} className="w-full h-64 object-cover" />
+        </div>
+        <p className="text-gray-700 leading-relaxed whitespace-pre-wrap">{tool.description}</p>
+      </div>
+    </div>
+  );
+}

--- a/app/tool/category/[category]/page.tsx
+++ b/app/tool/category/[category]/page.tsx
@@ -1,0 +1,39 @@
+import { ToolGrid } from "@/app/components/tool/ToolGrid";
+import { getToolsByCategory } from "@/lib/tool";
+import { notFound } from "next/navigation";
+import { ToolBreadcrumbs } from "@/app/components/tool/ToolBreadcrumbs";
+import { generateBreadcrumbJsonLd } from "@/lib/seo/breadcrumb";
+import Script from "next/script";
+
+export default async function ToolCategoryPage({ params }: { params: { category: string } }) {
+  const category = decodeURIComponent(params.category);
+  const tools = await getToolsByCategory(category);
+
+  if (tools.length === 0) {
+    notFound();
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? "";
+  const breadcrumbItems = [
+    { name: "Home", url: `${baseUrl}/` },
+    { name: "Tools", url: `${baseUrl}/tool` },
+    { name: category },
+  ];
+  const jsonLd = generateBreadcrumbJsonLd(breadcrumbItems);
+
+  return (
+    <section className="px-20 py-4 mt-8">
+      <Script id="breadcrumb-tool-category-jsonld" type="application/ld+json">
+        {JSON.stringify(jsonLd)}
+      </Script>
+
+      <ToolBreadcrumbs category={category} title="" />
+      <h1 className="py-4 mt-4 text-2xl text-gray-800">
+        ツール一覧<span>（{category}）</span>
+      </h1>
+      <div className="py-2">
+        <ToolGrid tools={tools} />
+      </div>
+    </section>
+  );
+}

--- a/app/tool/layout.tsx
+++ b/app/tool/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import { HeaderTool } from "../components/HeaderTool";
+import { Footer } from "../components/Footer";
+
+export const metadata: Metadata = {
+  title: "Tools",
+  description: "Tool distribution",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      <HeaderTool />
+      <main className="mt-[130px]">{children}</main>
+      <Footer />
+    </div>
+  );
+}

--- a/app/tool/page.tsx
+++ b/app/tool/page.tsx
@@ -1,7 +1,7 @@
 import { getPublishedTools } from "@/lib/tool";
 import { generateBreadcrumbJsonLd } from "@/lib/seo/breadcrumb";
 import Script from "next/script";
-import { Breadcrumbs } from "../components/blog/Breadcrumbs";
+import { ToolBreadcrumbs } from "../components/tool/ToolBreadcrumbs";
 import { ToolGrid } from "../components/tool/ToolGrid";
 
 export default async function ToolsPage() {
@@ -9,7 +9,7 @@ export default async function ToolsPage() {
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? "";
   const breadcrumbItems = [
     { name: "Home", url: `${baseUrl}/` },
-    { name: "Tools", url: `${baseUrl}/tools` },
+    { name: "Tools", url: `${baseUrl}/tool` },
   ];
   const jsonLd = generateBreadcrumbJsonLd(breadcrumbItems);
 
@@ -19,7 +19,7 @@ export default async function ToolsPage() {
         {JSON.stringify(jsonLd)}
       </Script>
 
-      <Breadcrumbs />
+      <ToolBreadcrumbs />
       <h1 className="py-4 mt-8 text-2xl text-gray-800">ツール一覧</h1>
       <div className="py-2">
         <ToolGrid tools={tools} />

--- a/lib/tool.ts
+++ b/lib/tool.ts
@@ -4,6 +4,7 @@ export async function getPublishedTools(): Promise<Tool[]> {
   return [
     {
       title: "請求書自動生成ツール",
+      category: "Excel VBA",
       description: "取引データからPDF請求書を一括作成。",
       date: "2025-07-10",
       imageUrl: "/Simplo_gray_main_sub.jpg",
@@ -13,6 +14,7 @@ export async function getPublishedTools(): Promise<Tool[]> {
     },
     {
       title: "日報自動化ツール",
+      category: "Excel VBA",
       description: "Excelで日報を一瞬で生成・送信。",
       date: "2025-07-09",
       imageUrl: "/Simplo_gray_main_sub.jpg",
@@ -20,5 +22,45 @@ export async function getPublishedTools(): Promise<Tool[]> {
       tags: ["Excel", "自動化"],
       slug: "daily-report-automation",
     },
+    {
+      title: "スプレッドシート整理GAS",
+      category: "Gas",
+      description: "大量データを自動整理するGASスクリプト。",
+      date: "2025-07-08",
+      imageUrl: "/Simplo_gray_main_sub.jpg",
+      author: "taku",
+      tags: ["GAS"],
+      slug: "spreadsheet-organizer",
+    },
+    {
+      title: "Markdown to HTML ツール",
+      category: "Webツール",
+      description: "Markdownをブラウザ上でHTMLに変換。",
+      date: "2025-07-07",
+      imageUrl: "/Simplo_gray_main_sub.jpg",
+      author: "taku",
+      tags: ["Web"],
+      slug: "markdown-html-converter",
+    },
+    {
+      title: "ファイル整理バッチ",
+      category: "Executable File",
+      description: "指定フォルダ内のファイルを自動で整理。",
+      date: "2025-07-06",
+      imageUrl: "/Simplo_gray_main_sub.jpg",
+      author: "taku",
+      tags: ["bat"],
+      slug: "file-organizer-batch",
+    },
   ];
+}
+
+export async function getToolBySlug(slug: string): Promise<Tool | undefined> {
+  const tools = await getPublishedTools();
+  return tools.find((tool) => tool.slug === slug);
+}
+
+export async function getToolsByCategory(category: string): Promise<Tool[]> {
+  const tools = await getPublishedTools();
+  return tools.filter((tool) => tool.category === category);
 }

--- a/types/tool.ts
+++ b/types/tool.ts
@@ -1,5 +1,6 @@
 export type Tool = {
   title: string;
+  category: string;
   description: string;
   date: string;
   imageUrl: string;


### PR DESCRIPTION
## Summary
- add category field to `Tool` type
- expand tool metadata and helper functions
- implement dedicated components for tool pages
- create new `/tool` routes with category and detail pages
- expose tools via API

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872731887008328ac128838cea3f75b