### PR TITLE
Implement Supabase and Notion API integration

### DIFF
--- a/app/api/contents/[id]/route.ts
+++ b/app/api/contents/[id]/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { getContentById } from '@/lib/supabase';
+import { getPageContentByTitle } from '@/lib/notion';
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const id = parseInt(params.id, 10);
+  const content = await getContentById(id);
+  if (!content) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const notion = await getPageContentByTitle(content.document);
+  return NextResponse.json({ ...content, notion });
+}

--- a/app/api/contents/route.ts
+++ b/app/api/contents/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { getPublishedContents } from '@/lib/supabase';
+
+export async function GET() {
+  const contents = await getPublishedContents();
+  return NextResponse.json(contents);
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,0 +1,36 @@
+const SUPABASE_URL = process.env.SUPABASE_URL!;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+
+import { Contents } from '@/types/contents';
+
+async function supabaseFetch<T>(path: string, params: string) {
+  const url = `${SUPABASE_URL}/rest/v1/${path}?${params}`;
+  const res = await fetch(url, {
+    headers: {
+      apikey: SUPABASE_SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+    },
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    throw new Error(`Supabase fetch failed: ${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+
+export async function getPublishedContents(): Promise<Contents[]> {
+  const params = new URLSearchParams({
+    select: '*',
+    isPublished: 'eq.true',
+  }).toString();
+  return supabaseFetch<Contents[]>('Contents', params);
+}
+
+export async function getContentById(id: number): Promise<Contents | undefined> {
+  const params = new URLSearchParams({
+    select: '*',
+    id: `eq.${id}`,
+  }).toString();
+  const data = await supabaseFetch<Contents[]>('Contents', params);
+  return data[0];
+}

--- a/lib/tool.ts
+++ b/lib/tool.ts
@@ -1,113 +1,37 @@
-import { Tool } from "@/types/tool";
+import { Contents } from '@/types/contents';
+import { getPublishedContents, getContentById } from '@/lib/supabase';
+import { Tool } from '@/types/tool';
+
+// Convert Contents record to Tool type
+function mapContentsToTool(item: Contents): Tool {
+  return {
+    title: item.title,
+    category: item.category,
+    description: item.description ?? '',
+    date: item.createdAt,
+    imageUrl: item.filePath ?? '',
+    author: item.authorId,
+    tags: item.tags,
+    slug: item.id.toString(),
+    buttonType: item.deliveryType === 'FILE' ? 'download' : 'link',
+    buttonUrl: item.url ?? '',
+  };
+}
 
 export async function getPublishedTools(): Promise<Tool[]> {
-  return [
-    {
-      title: "請求書自動生成ツール",
-      category: "Excel VBA",
-      description: "取引データからPDF請求書を一括作成。",
-      date: "2025-07-10",
-      imageUrl: "/Simplo_gray_main_sub.jpg",
-      author: "taku",
-      tags: ["請求書", "自動化", "業務効率化"],
-      slug: "invoice-generator",
-      buttonType: "download",
-      buttonUrl: "/dummy/invoice-generator.zip",
-    },
-    {
-      title: "日報自動化ツール",
-      category: "Excel VBA",
-      description: "Excelで日報を一瞬で生成・送信。",
-      date: "2025-07-09",
-      imageUrl: "/Simplo_gray_main_sub.jpg",
-      author: "taku",
-      tags: ["Excel", "自動化"],
-      slug: "daily-report-automation",
-      buttonType: "download",
-      buttonUrl: "/dummy/daily-report-automation.zip",
-    },
-    {
-      title: "スプレッドシート整理GAS",
-      category: "Gas",
-      description: "大量データを自動整理するGASスクリプト。",
-      date: "2025-07-08",
-      imageUrl: "/Simplo_gray_main_sub.jpg",
-      author: "taku",
-      tags: ["GAS"],
-      slug: "spreadsheet-organizer",
-      buttonType: "link",
-      buttonUrl: "https://example.com/spreadsheet-organizer",
-    },
-    {
-      title: "Markdown to HTML ツール",
-      category: "Webツール",
-      description: "Markdownをブラウザ上でHTMLに変換。",
-      date: "2025-07-07",
-      imageUrl: "/Simplo_gray_main_sub.jpg",
-      author: "taku",
-      tags: ["Web"],
-      slug: "markdown-html-converter",
-      buttonType: "link",
-      buttonUrl: "https://example.com/markdown-html-converter",
-    },
-    {
-      title: "ファイル整理バッチ",
-      category: "Executable File",
-      description: "指定フォルダ内のファイルを自動で整理。",
-      date: "2025-07-06",
-      imageUrl: "/Simplo_gray_main_sub.jpg",
-      author: "taku",
-      tags: ["bat"],
-      slug: "file-organizer-batch",
-      buttonType: "download",
-      buttonUrl: "/dummy/file-organizer-batch.zip",
-    },
-    // ↓ 重複データも修正
-    {
-      title: "スプレッドシート整理GAS",
-      category: "Gas",
-      description: "大量データを自動整理するGASスクリプト。",
-      date: "2025-07-08",
-      imageUrl: "/Simplo_gray_main_sub.jpg",
-      author: "taku",
-      tags: ["GAS"],
-      slug: "spreadsheet-organizer-2", // ← slug を一意に変更
-      buttonType: "link",
-      buttonUrl: "https://example.com/spreadsheet-organizer",
-    },
-    {
-      title: "Markdown to HTML ツール",
-      category: "Webツール",
-      description: "Markdownをブラウザ上でHTMLに変換。",
-      date: "2025-07-07",
-      imageUrl: "/Simplo_gray_main_sub.jpg",
-      author: "taku",
-      tags: ["Web"],
-      slug: "markdown-html-converter-2",
-      buttonType: "link",
-      buttonUrl: "https://example.com/markdown-html-converter",
-    },
-    {
-      title: "ファイル整理バッチ",
-      category: "Executable File",
-      description: "指定フォルダ内のファイルを自動で整理。",
-      date: "2025-07-06",
-      imageUrl: "/Simplo_gray_main_sub.jpg",
-      author: "taku",
-      tags: ["bat"],
-      slug: "file-organizer-batch-2",
-      buttonType: "download",
-      buttonUrl: "/dummy/file-organizer-batch.zip",
-    },
-  ];
+  const contents = await getPublishedContents();
+  return contents.filter((c) => c.type === 'TOOL').map(mapContentsToTool);
 }
 
 export async function getToolBySlug(slug: string): Promise<Tool | undefined> {
-  const tools = await getPublishedTools();
-  return tools.find((tool) => tool.slug === slug);
+  const id = Number(slug);
+  const content = await getContentById(id);
+  return content && content.type === 'TOOL' ? mapContentsToTool(content) : undefined;
 }
 
 export async function getToolsByCategory(category: string): Promise<Tool[]> {
-  const tools = await getPublishedTools();
-  return tools.filter((tool) => tool.category === category);
+  const contents = await getPublishedContents();
+  return contents
+    .filter((c) => c.type === 'TOOL' && c.category === category)
+    .map(mapContentsToTool);
 }

--- a/types/contents.ts
+++ b/types/contents.ts
@@ -1,0 +1,18 @@
+export type Contents = {
+  id: number;
+  title: string;
+  document: string;
+  type: 'TOOL' | 'TEMPLATE';
+  deliveryType: 'FILE' | 'URL';
+  url?: string | null;
+  filePath?: string | null;
+  description?: string | null;
+  category: string;
+  tags: string[];
+  starRating: number;
+  downloadCount: number;
+  isPublished: boolean;
+  createdAt: string;
+  updatedAt: string;
+  authorId: string;
+};


### PR DESCRIPTION
## Summary
- add Supabase REST helper and types
- expose contents API endpoints
- convert tool helpers to load data from Supabase
- provide detailed content endpoint using Notion

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_687bb4167fc48328bb92c3f935d030a8