### PR TITLE
Add Supabase CRUD endpoints

### DIFF
--- a/app/api/contents/[id]/route.ts
+++ b/app/api/contents/[id]/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from 'next/server';
-import { getContentById } from '@/lib/supabase';
+import {
+  getContentById,
+  updateContent,
+  deleteContent,
+  uploadFile,
+} from '@/lib/supabase';
 import { getPageContentByTitle } from '@/lib/notion';
 
 export async function GET(
@@ -14,4 +19,36 @@ export async function GET(
 
   const notion = await getPageContentByTitle(content.document);
   return NextResponse.json({ ...content, notion });
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const id = parseInt(params.id, 10);
+  const form = await request.formData();
+  const json = form.get('data');
+  if (typeof json !== 'string') {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+  const fields = JSON.parse(json) as any;
+  const file = form.get('file') as File | null;
+
+  if (file) {
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const url = await uploadFile(buffer, file.name, file.type);
+    fields.filePath = url;
+  }
+
+  const updated = await updateContent(id, fields);
+  return NextResponse.json(updated);
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const id = parseInt(params.id, 10);
+  await deleteContent(id);
+  return NextResponse.json({ success: true });
 }

--- a/app/api/contents/route.ts
+++ b/app/api/contents/route.ts
@@ -1,7 +1,34 @@
 import { NextResponse } from 'next/server';
-import { getPublishedContents } from '@/lib/supabase';
+import {
+  getPublishedContents,
+  createContent,
+  uploadFile,
+} from '@/lib/supabase';
+
+type FormFields = Omit<Parameters<typeof createContent>[0], 'filePath'> & {
+  file?: File | null;
+};
 
 export async function GET() {
   const contents = await getPublishedContents();
   return NextResponse.json(contents);
+}
+
+export async function POST(request: Request) {
+  const form = await request.formData();
+  const json = form.get('data');
+  if (typeof json !== 'string') {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+  const fields: FormFields = JSON.parse(json);
+  const file = form.get('file') as File | null;
+
+  if (file) {
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const url = await uploadFile(buffer, file.name, file.type);
+    fields.filePath = url;
+  }
+
+  const created = await createContent(fields);
+  return NextResponse.json(created, { status: 201 });
 }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,5 +1,8 @@
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const SUPABASE_BUCKET = process.env.NEXT_PUBLIC_SUPABASE_BUCKET ?? "public";
+
+import { randomUUID } from "crypto";
 
 import { Contents } from "@/types/contents";
 
@@ -35,4 +38,83 @@ export async function getContentById(
   }).toString();
   const data = await supabaseFetch<Contents[]>("Contents", params);
   return data[0];
+}
+
+// ------------------------------
+// mutation helpers
+// ------------------------------
+
+async function supabaseRequest<T>(
+  method: string,
+  path: string,
+  params: string,
+  body?: unknown,
+  contentType = "application/json"
+) {
+  const url = `${SUPABASE_URL}/rest/v1/${path}?${params}`;
+  const headers: Record<string, string> = {
+    apikey: SUPABASE_SERVICE_ROLE_KEY,
+    Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+  };
+  if (body) {
+    headers["Content-Type"] = contentType;
+    headers["Prefer"] = "return=representation";
+  }
+
+  const res = await fetch(url, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  if (!res.ok) {
+    throw new Error(`Supabase request failed: ${res.status}`);
+  }
+
+  return body ? ((await res.json()) as T) : (undefined as T);
+}
+
+export async function createContent(data: Partial<Contents>): Promise<Contents> {
+  const result = await supabaseRequest<Contents[]>("POST", "Contents", "", [data]);
+  return result[0];
+}
+
+export async function updateContent(
+  id: number,
+  data: Partial<Contents>
+): Promise<Contents> {
+  const params = new URLSearchParams({ id: `eq.${id}` }).toString();
+  const result = await supabaseRequest<Contents[]>("PATCH", "Contents", params, data);
+  return result[0];
+}
+
+export async function deleteContent(id: number): Promise<void> {
+  const params = new URLSearchParams({ id: `eq.${id}` }).toString();
+  await supabaseRequest("DELETE", "Contents", params);
+}
+
+export async function uploadFile(
+  file: ArrayBuffer | Buffer,
+  filename: string,
+  contentType: string
+): Promise<string> {
+  const uniqueName = `${randomUUID()}-${filename}`;
+  const url = `${SUPABASE_URL}/storage/v1/object/${SUPABASE_BUCKET}/${uniqueName}`;
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      apikey: SUPABASE_SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+      "Content-Type": contentType,
+      "x-upsert": "true",
+    },
+    body: file,
+  });
+
+  if (!res.ok) {
+    throw new Error(`Supabase file upload failed: ${res.status}`);
+  }
+
+  return `${SUPABASE_URL}/storage/v1/object/public/${SUPABASE_BUCKET}/${uniqueName}`;
 }


### PR DESCRIPTION
## Summary
- enable creating new contents with file upload to Supabase storage
- allow updating and deleting contents
- implement helper utilities for content mutations and storage upload

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687caa6eff9083289be0c02f6acea703