### PR TITLE
Add tool management form

### DIFF
--- a/app/components/tool/ToolForm.tsx
+++ b/app/components/tool/ToolForm.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+
+import type { Contents } from "@/types/contents";
+
+const schema = z
+  .object({
+    title: z.string().min(1, "必須項目です"),
+    document: z.string().min(1, "必須項目です"),
+    category: z.string().min(1, "必須項目です"),
+    tags: z.string().optional(),
+    description: z.string().optional(),
+    deliveryType: z.enum(["FILE", "URL"]),
+    url: z.string().optional(),
+    file: z.any().optional(),
+    isPublished: z.boolean().optional(),
+    authorId: z.string().min(1, "必須項目です"),
+  })
+  .refine(
+    (data) => {
+      if (data.deliveryType === "URL") {
+        return !!data.url;
+      }
+      if (data.deliveryType === "FILE") {
+        return !!data.file;
+      }
+      return true;
+    },
+    {
+      message: "URL またはファイルを指定してください",
+      path: ["url"],
+    }
+  );
+
+type FormValues = z.infer<typeof schema>;
+
+type Props = {
+  defaultValues?: Partial<FormValues>;
+  id?: number;
+};
+
+export function ToolForm({ defaultValues, id }: Props) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      title: defaultValues?.title ?? "",
+      document: defaultValues?.document ?? "",
+      category: defaultValues?.category ?? "",
+      tags: defaultValues?.tags ?? "",
+      description: defaultValues?.description ?? "",
+      deliveryType: (defaultValues?.deliveryType as "FILE" | "URL") ?? "FILE",
+      url: defaultValues?.url ?? "",
+      file: undefined,
+      isPublished: defaultValues?.isPublished ?? false,
+      authorId: defaultValues?.authorId ?? "",
+    },
+  });
+
+  const onSubmit = async (data: FormValues) => {
+    setLoading(true);
+    const fields: any = {
+      title: data.title,
+      document: data.document,
+      type: "TOOL",
+      category: data.category,
+      tags: data.tags ? data.tags.split(/\s*,\s*/) : [],
+      description: data.description,
+      deliveryType: data.deliveryType,
+      url: data.url,
+      isPublished: data.isPublished,
+      authorId: data.authorId,
+    };
+
+    const formData = new FormData();
+    formData.append("data", JSON.stringify(fields));
+    if (data.file instanceof File) {
+      formData.append("file", data.file);
+    }
+
+    const res = await fetch(id ? `/api/contents/${id}` : "/api/contents", {
+      method: id ? "PUT" : "POST",
+      body: formData,
+    });
+
+    setLoading(false);
+    if (res.ok) {
+      router.push("/tool");
+    } else {
+      alert("送信に失敗しました");
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="title"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>タイトル</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="document"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>ドキュメントID</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="category"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>カテゴリー</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="tags"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>タグ（カンマ区切り）</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>説明</FormLabel>
+              <FormControl>
+                <Textarea rows={5} {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="deliveryType"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>配布方法</FormLabel>
+              <FormControl>
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="選択" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="FILE">FILE</SelectItem>
+                    <SelectItem value="URL">URL</SelectItem>
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        {form.watch("deliveryType") === "URL" ? (
+          <FormField
+            control={form.control}
+            name="url"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>URL</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        ) : (
+          <FormField
+            control={form.control}
+            name="file"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>ファイル</FormLabel>
+                <FormControl>
+                  <Input type="file" onChange={(e) => field.onChange(e.target.files?.[0])} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
+        <FormField
+          control={form.control}
+          name="isPublished"
+          render={({ field }) => (
+            <FormItem className="flex flex-row items-center gap-2">
+              <FormControl>
+                <Checkbox checked={field.value} onCheckedChange={field.onChange} />
+              </FormControl>
+              <FormLabel>公開する</FormLabel>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="authorId"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>作者ID</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="pt-4">
+          <Button type="submit" disabled={loading}>
+            {loading ? "送信中..." : "保存"}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/app/tool/[slug]/edit/page.tsx
+++ b/app/tool/[slug]/edit/page.tsx
@@ -1,0 +1,32 @@
+import { notFound } from "next/navigation";
+import { ToolForm } from "@/app/components/tool/ToolForm";
+import { getContentById } from "@/lib/supabase";
+
+export default async function EditToolPage({ params }: { params: { slug: string } }) {
+  const id = Number(params.slug);
+  const content = await getContentById(id);
+
+  if (!content || content.type !== "TOOL") {
+    notFound();
+  }
+
+  return (
+    <section className="p-4">
+      <h1 className="text-xl font-bold mb-4">ツール編集</h1>
+      <ToolForm
+        id={content.id}
+        defaultValues={{
+          title: content.title,
+          document: content.document,
+          category: content.category,
+          tags: content.tags.join(", "),
+          description: content.description ?? "",
+          deliveryType: content.deliveryType,
+          url: content.url ?? "",
+          isPublished: content.isPublished,
+          authorId: content.authorId,
+        }}
+      />
+    </section>
+  );
+}

--- a/app/tool/new/page.tsx
+++ b/app/tool/new/page.tsx
@@ -1,0 +1,10 @@
+import { ToolForm } from "@/app/components/tool/ToolForm";
+
+export default function NewToolPage() {
+  return (
+    <section className="p-4">
+      <h1 className="text-xl font-bold mb-4">ツール登録</h1>
+      <ToolForm />
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add tool registration form component
- add page to create new tools
- add page to edit existing tools

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cb116fc84832897a063e72216116a