### PR TITLE
Add storage management for tool files

### DIFF
--- a/app/components/tool/ToolCard.tsx
+++ b/app/components/tool/ToolCard.tsx
@@ -6,21 +6,21 @@ import { tagColors } from "@/lib/utils/tag_color";
 
 export function ToolCard({ tool }: { tool: Tool }) {
   return (
-    <Link
-      href={`/tool/${tool.slug}`}
-      className="block rounded-xl shadow bg-white overflow-hidden hover:shadow-md transition"
-    >
-      <Image
-        src={tool.imageUrl}
-        alt={tool.title}
-        width={600}
-        height={400}
-        className="w-full h-48 object-cover"
-      />
+    <div className="rounded-xl shadow bg-white overflow-hidden hover:shadow-md transition">
+      <Link href={`/tool/${tool.slug}`}> 
+        <Image
+          src={tool.imageUrl}
+          alt={tool.title}
+          width={600}
+          height={400}
+          className="w-full h-48 object-cover"
+        />
+      </Link>
       <div className="p-4 space-y-2">
-        <h3 className="text-lg font-semibold">
+        <Link href={`/tool/${tool.slug}`}
+          className="text-lg font-semibold hover:underline block">
           {tool.title}（{tool.category}）
-        </h3>
+        </Link>
         <p className="text-sm text-gray-600">{tool.description}</p>
         <div className="flex justify-between text-xs text-gray-500">
           <span>{tool.date}</span>
@@ -38,10 +38,31 @@ export function ToolCard({ tool }: { tool: Tool }) {
             </span>
           ))}
         </div>
-        <span className="inline-block mt-2 text-sm text-blue-600 hover:underline">
-          詳細はこちら
-        </span>
+        <div className="flex justify-between items-center mt-2">
+          <Link href={`/tool/${tool.slug}`} className="text-sm text-blue-600 hover:underline">
+            詳細はこちら
+          </Link>
+          {tool.buttonType === 'download' && tool.buttonUrl ? (
+            <a
+              href={tool.buttonUrl}
+              download
+              className="text-sm text-blue-600 hover:underline"
+            >
+              ダウンロード
+            </a>
+          ) : null}
+          {tool.buttonType === 'link' && tool.buttonUrl ? (
+            <a
+              href={tool.buttonUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-blue-600 hover:underline"
+            >
+              外部リンク
+            </a>
+          ) : null}
+        </div>
       </div>
-    </Link>
+    </div>
   );
 }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -118,3 +118,21 @@ export async function uploadFile(
 
   return `${SUPABASE_URL}/storage/v1/object/public/${SUPABASE_BUCKET}/${uniqueName}`;
 }
+
+export async function deleteFile(fileUrl: string): Promise<void> {
+  if (!fileUrl) return;
+  const prefix = `${SUPABASE_URL}/storage/v1/object/public/${SUPABASE_BUCKET}/`;
+  if (!fileUrl.startsWith(prefix)) return;
+  const path = fileUrl.slice(prefix.length);
+  const url = `${SUPABASE_URL}/storage/v1/object/${SUPABASE_BUCKET}/${path}`;
+  const res = await fetch(url, {
+    method: "DELETE",
+    headers: {
+      apikey: SUPABASE_SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+    },
+  });
+  if (!res.ok && res.status !== 404) {
+    throw new Error(`Supabase file delete failed: ${res.status}`);
+  }
+}

--- a/lib/tool.ts
+++ b/lib/tool.ts
@@ -14,7 +14,10 @@ function mapContentsToTool(item: Contents): Tool {
     tags: item.tags,
     slug: item.id.toString(),
     buttonType: item.deliveryType === 'FILE' ? 'download' : 'link',
-    buttonUrl: item.url ?? '',
+    buttonUrl:
+      item.deliveryType === 'FILE'
+        ? item.filePath ?? ''
+        : item.url ?? '',
   };
 }
 


### PR DESCRIPTION
## Summary
- allow file deletion in Supabase storage
- fix tool mapping to use uploaded files for download
- show download/links in tool grid
- remove files when editing or deleting a tool

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d08f9bedc8328aeb96f516e1bde6b