### PR TITLE
Add tool creation link and improve form UI

### DIFF
--- a/app/components/tool/ToolForm.tsx
+++ b/app/components/tool/ToolForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -78,6 +78,12 @@ export function ToolForm({ defaultValues, id }: Props) {
     },
   });
 
+  useEffect(() => {
+    if (!defaultValues?.document) {
+      form.setValue("document", `tool-${crypto.randomUUID()}`);
+    }
+  }, [defaultValues?.document, form]);
+
   const onSubmit = async (data: FormValues) => {
     setLoading(true);
     const fields: any = {
@@ -114,7 +120,7 @@ export function ToolForm({ defaultValues, id }: Props) {
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 max-w-md mx-auto">
         <FormField
           control={form.control}
           name="title"
@@ -122,7 +128,7 @@ export function ToolForm({ defaultValues, id }: Props) {
             <FormItem>
               <FormLabel>タイトル</FormLabel>
               <FormControl>
-                <Input {...field} />
+                <Input {...field} className="max-w-md" />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -135,7 +141,7 @@ export function ToolForm({ defaultValues, id }: Props) {
             <FormItem>
               <FormLabel>ドキュメントID</FormLabel>
               <FormControl>
-                <Input {...field} />
+                <Input {...field} className="max-w-md" readOnly />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -148,7 +154,7 @@ export function ToolForm({ defaultValues, id }: Props) {
             <FormItem>
               <FormLabel>カテゴリー</FormLabel>
               <FormControl>
-                <Input {...field} />
+                <Input {...field} className="max-w-md" />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -161,7 +167,7 @@ export function ToolForm({ defaultValues, id }: Props) {
             <FormItem>
               <FormLabel>タグ（カンマ区切り）</FormLabel>
               <FormControl>
-                <Input {...field} />
+                <Input {...field} className="max-w-md" />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -174,7 +180,7 @@ export function ToolForm({ defaultValues, id }: Props) {
             <FormItem>
               <FormLabel>説明</FormLabel>
               <FormControl>
-                <Textarea rows={5} {...field} />
+                <Textarea rows={5} {...field} className="max-w-md" />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -188,7 +194,7 @@ export function ToolForm({ defaultValues, id }: Props) {
               <FormLabel>配布方法</FormLabel>
               <FormControl>
                 <Select value={field.value} onValueChange={field.onChange}>
-                  <SelectTrigger>
+                  <SelectTrigger className="max-w-md bg-white hover:bg-gray-50">
                     <SelectValue placeholder="選択" />
                   </SelectTrigger>
                   <SelectContent>
@@ -209,7 +215,7 @@ export function ToolForm({ defaultValues, id }: Props) {
               <FormItem>
                 <FormLabel>URL</FormLabel>
                 <FormControl>
-                  <Input {...field} />
+                  <Input {...field} className="max-w-md" />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -223,7 +229,11 @@ export function ToolForm({ defaultValues, id }: Props) {
               <FormItem>
                 <FormLabel>ファイル</FormLabel>
                 <FormControl>
-                  <Input type="file" onChange={(e) => field.onChange(e.target.files?.[0])} />
+                  <Input
+                    type="file"
+                    onChange={(e) => field.onChange(e.target.files?.[0])}
+                    className="max-w-md"
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -249,14 +259,18 @@ export function ToolForm({ defaultValues, id }: Props) {
             <FormItem>
               <FormLabel>作者ID</FormLabel>
               <FormControl>
-                <Input {...field} />
+                <Input {...field} className="max-w-md" />
               </FormControl>
               <FormMessage />
             </FormItem>
           )}
         />
         <div className="pt-4">
-          <Button type="submit" disabled={loading}>
+          <Button
+            type="submit"
+            disabled={loading}
+            className="bg-blue-600 text-white hover:bg-blue-700"
+          >
             {loading ? "送信中..." : "保存"}
           </Button>
         </div>

--- a/app/tool/page.tsx
+++ b/app/tool/page.tsx
@@ -3,6 +3,8 @@ import { generateBreadcrumbJsonLd } from "@/lib/seo/breadcrumb";
 import Script from "next/script";
 import { ToolBreadcrumbs } from "../components/tool/ToolBreadcrumbs";
 import { ToolGrid } from "../components/tool/ToolGrid";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 
 export default async function ToolsPage() {
   const tools = await getPublishedTools();
@@ -20,7 +22,12 @@ export default async function ToolsPage() {
       </Script>
 
       <ToolBreadcrumbs />
-      <h1 className="py-4 mt-8 text-2xl text-gray-800">ツール一覧</h1>
+      <div className="flex items-center justify-between py-4 mt-8">
+        <h1 className="text-2xl text-gray-800">ツール一覧</h1>
+        <Link href="/tool/new">
+          <Button size="sm">新規登録</Button>
+        </Link>
+      </div>
       <div className="py-2">
         <ToolGrid tools={tools} />
       </div>

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -107,7 +107,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground hover:bg-gray-100 bg-white [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- add '新規登録' button on tool listing page
- generate document ID automatically using `crypto.randomUUID`
- restrict form width and style inputs for a compact layout
- colorize select menu and save button

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687e212dec388328b35b725ce11bca47