### PR TITLE
Fix Supabase upload

### DIFF
--- a/app/api/contents/[id]/route.ts
+++ b/app/api/contents/[id]/route.ts
@@ -42,8 +42,8 @@ export async function PUT(
   const file = form.get('file') as File | null;
 
   if (file) {
-    const buffer = Buffer.from(await file.arrayBuffer());
-    const url = await uploadFile(buffer, file.name, file.type);
+    const arrayBuffer = await file.arrayBuffer();
+    const url = await uploadFile(arrayBuffer, file.name, file.type);
     fields.filePath = url;
     if (original.filePath) {
       await deleteFile(original.filePath);

--- a/app/api/contents/route.ts
+++ b/app/api/contents/route.ts
@@ -24,8 +24,8 @@ export async function POST(request: Request) {
   const file = form.get('file') as File | null;
 
   if (file) {
-    const buffer = Buffer.from(await file.arrayBuffer());
-    const url = await uploadFile(buffer, file.name, file.type);
+    const arrayBuffer = await file.arrayBuffer();
+    const url = await uploadFile(arrayBuffer, file.name, file.type);
     fields.filePath = url;
   }
 

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -113,7 +113,7 @@ export async function uploadFile(
   const blob = new Blob([file], { type: contentType });
 
   const res = await fetch(url, {
-    method: "PUT",
+    method: "POST",
     headers: {
       apikey: SUPABASE_SERVICE_ROLE_KEY,
       Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,


### PR DESCRIPTION
## Summary
- fix Supabase upload POST method
- send uploaded file as ArrayBuffer

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e4809bc6883288688e313ba2ff249