### PR TITLE
Fix tool images

### DIFF
--- a/lib/tool.ts
+++ b/lib/tool.ts
@@ -2,14 +2,24 @@ import { Contents } from '@/types/contents';
 import { getPublishedContents, getContentById } from '@/lib/supabase';
 import { Tool } from '@/types/tool';
 
+// Check if file path points to an image
+function isImageFile(path: string | null | undefined): boolean {
+  if (!path) return false;
+  return /\.(png|jpe?g|gif|svg|webp)$/i.test(path);
+}
+
 // Convert Contents record to Tool type
 function mapContentsToTool(item: Contents): Tool {
+  const imageUrl = isImageFile(item.filePath)
+    ? (item.filePath as string)
+    : '/Simplo_gray_main_sub.jpg';
+
   return {
     title: item.title,
     category: item.category,
     description: item.description ?? '',
     date: item.createdAt,
-    imageUrl: item.filePath ?? '',
+    imageUrl,
     author: item.authorId,
     tags: item.tags,
     slug: item.id.toString(),

--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,12 @@ const nextConfig = {
         port: "",
         pathname: "/**",
       },
+      {
+        protocol: "https",
+        hostname: "**.supabase.co",
+        port: "",
+        pathname: "/**",
+      },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- allow Supabase remote images
- fallback to default image for tool files

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884ad5cdb108328a129c80133fd93e3