### PR TITLE
Improve header and product form

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -24,11 +24,13 @@ export function Header() {
 
   return (
     <header
-      className={`fixed top-0 left-0 w-full z-50 bg-white transition-all duration-300 shadow ${
-        scrolled ? "py-2" : "py-4"
-      }`}
+      className={`fixed top-0 left-0 w-full z-50 transition-all duration-300 ${
+        scrolled
+          ? "bg-white/80 backdrop-blur-md shadow-md border-b"
+          : "bg-transparent"
+      } ${scrolled ? "py-2" : "py-4"}`}
     >
-      <div className="container mx-auto flex items-center justify-between px-4">
+      <div className="max-w-7xl mx-auto flex items-center justify-between px-4">
         <Link href="/" className="text-xl font-bold">
           <Image
             src={SimproSvg}
@@ -41,7 +43,7 @@ export function Header() {
 
         {/* Desktopメニュー */}
         <NavigationMenu className="hidden md:block">
-          <NavigationMenuList className="space-x-6">
+          <NavigationMenuList className="space-x-8 font-medium tracking-wide">
             <NavigationMenuItem>
               <Link href="#services" className="hover:underline">
                 サービス
@@ -90,7 +92,7 @@ export function Header() {
       <div
         className={`md:hidden overflow-hidden transition-all duration-300 ease-in-out ${
           menuOpen ? "max-h-60 opacity-100 py-4" : "max-h-0 opacity-0 py-0"
-        } bg-white px-6`}
+        } bg-white/90 backdrop-blur-md px-6`}
       >
         <ul className="space-y-4 text-base">
           <li>

--- a/app/components/product/ProductForm.tsx
+++ b/app/components/product/ProductForm.tsx
@@ -32,6 +32,7 @@ const schema = z
   .object({
     title: z.string().min(1, "必須項目です"),
     document: z.string().min(1, "必須項目です"),
+    type: z.enum(["TOOL", "TEMPLATE"]),
     category: z.string().min(1, "必須項目です"),
     tags: z.string().optional(),
     description: z.string().optional(),
@@ -73,6 +74,7 @@ export function ProductForm({ defaultValues, id }: Props) {
     defaultValues: {
       title: defaultValues?.title ?? "",
       document: defaultValues?.document ?? "",
+      type: (defaultValues?.type as "TOOL" | "TEMPLATE") ?? "TOOL",
       category: defaultValues?.category ?? "",
       tags: defaultValues?.tags ?? "",
       description: defaultValues?.description ?? "",
@@ -99,7 +101,7 @@ export function ProductForm({ defaultValues, id }: Props) {
     const fields: Partial<ProductRecord> = {
       title: safeTitle,
       document: data.document,
-      type: "TOOL",
+      type: data.type,
       category: data.category,
       tags: `{${(data.tags ?? "")
         .split(/\s*,\s*/)
@@ -160,6 +162,27 @@ export function ProductForm({ defaultValues, id }: Props) {
               <FormLabel>ドキュメントID</FormLabel>
               <FormControl>
                 <Input {...field} className="max-w-md" readOnly />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="type"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>種類</FormLabel>
+              <FormControl>
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <SelectTrigger className="max-w-md bg-white hover:bg-gray-50">
+                    <SelectValue placeholder="選択" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="TOOL">tool</SelectItem>
+                    <SelectItem value="TEMPLATE">template</SelectItem>
+                  </SelectContent>
+                </Select>
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/app/product/layout.tsx
+++ b/app/product/layout.tsx
@@ -9,9 +9,9 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div>
+    <div className="flex flex-col min-h-screen">
       <HeaderProduct />
-      <main className="mt-[130px]">{children}</main>
+      <main className="flex-grow mt-[130px]">{children}</main>
       <Footer />
     </div>
   );

--- a/app/product/page.tsx
+++ b/app/product/page.tsx
@@ -25,7 +25,9 @@ export default async function ProductsPage() {
       <div className="flex items-center justify-between py-4 mt-8">
         <h1 className="text-2xl text-gray-800">プロダクト一覧</h1>
         <Link href="/product/new">
-          <Button size="sm">新規登録</Button>
+          <Button size="sm" className="bg-blue-600 text-white hover:bg-blue-700">
+            新規登録
+          </Button>
         </Link>
       </div>
       <div className="py-2">


### PR DESCRIPTION
## Summary
- refine header with translucent background and stylish navigation
- color new registration button blue
- add product type selection in form
- keep footer at bottom on product pages

## Testing
- `npm install` *(fails: network restricted)*
- `npm run lint` *(fails: next not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68862e108f908328a0fda03e9b74ff17