### PR TITLE
Improve product form layout and header

### DIFF
--- a/app/components/CategoryButton.tsx
+++ b/app/components/CategoryButton.tsx
@@ -1,0 +1,16 @@
+"use client";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export function CategoryButton({ label }: { label: string }) {
+  return (
+    <Button
+      asChild
+      variant="secondary"
+      size="sm"
+      className="bg-white text-zinc-800 hover:bg-zinc-100 shadow"
+    >
+      <Link href={`/product/category/${encodeURIComponent(label)}`}>{label}</Link>
+    </Button>
+  );
+}

--- a/app/components/HeaderProduct.tsx
+++ b/app/components/HeaderProduct.tsx
@@ -1,129 +1,79 @@
 "use client";
 import { useEffect, useState } from "react";
-import {
-  NavigationMenu,
-  NavigationMenuItem,
-  NavigationMenuList,
-} from "@/components/ui/navigation-menu";
 import Link from "next/link";
-import SimproSvg from "@/public/Simplo_gray_main_sub.svg";
 import Image from "next/image";
-import { Menu, X } from "lucide-react";
+import SimproSvg from "@/public/Simplo_gray_main_sub.svg";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { CategoryButton } from "./CategoryButton";
 
-const toolCategories = ["Webツール", "Gas", "Excel VBA", "Executable File"];
+const toolCategories = ["Webツール", "GAS", "Excel VBA", "Executable File"];
 const templateCategories = ["Webサイトテンプレート", "Webアプリテンプレート"];
+
 export function HeaderProduct() {
   const [hideHeader, setHideHeader] = useState(false);
-  const [lastScrollY, setLastScrollY] = useState(0);
-  const [menuOpen, setMenuOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState("tool");
 
   useEffect(() => {
     const handleScroll = () => {
       const currentY = window.scrollY;
-      setHideHeader(currentY > lastScrollY && currentY > 80);
-      setLastScrollY(currentY);
+      setHideHeader(currentY > 80);
     };
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
-  }, [lastScrollY]);
+  }, []);
 
   return (
     <header
-      className={`fixed top-0 left-0 w-full z-50 transition-transform duration-300 ${
-        hideHeader ? "-translate-y-full" : "translate-y-0"
-      }`}
+      className={`fixed top-0 left-0 w-full z-50 transition-transform duration-300 ${hideHeader ? "-translate-y-full" : "translate-y-0"}`}
     >
-      <div className="bg-white shadow">
-        <div className="container mx-auto flex items-center justify-between px-4 py-4">
-          <div className="flex items-center gap-2">
-            <Link href="/" className="text-xl font-bold">
-              <Image src={SimproSvg} alt="Simpro Logo" width={100} height={40} priority />
+      <div className="border-b bg-white shadow-sm">
+        <div className="max-w-7xl mx-auto flex justify-between items-center px-4 py-3">
+          <Link href="/" className="flex items-center gap-2 text-lg font-bold">
+            <Image src={SimproSvg} alt="Simpro Logo" width={100} height={40} priority />
+            <span className="text-black">- Products</span>
+          </Link>
+          <div className="flex-1 mx-4 hidden md:block" />
+          <nav className="flex gap-6 text-sm font-medium">
+            <Link href="/" className="hover:underline">
+              TOP
             </Link>
-            <p className="text-black text-xl"> - Products</p>
-          </div>
-          <NavigationMenu className="hidden md:block">
-            <NavigationMenuList className="space-x-6">
-              <NavigationMenuItem>
-                <Link href="#top" className="hover:underline">
-                  TOP
-                </Link>
-              </NavigationMenuItem>
-              <NavigationMenuItem>
-                <Link href="#category" className="hover:underline">
-                  カテゴリ
-                </Link>
-              </NavigationMenuItem>
-              <NavigationMenuItem>
-                <Link href="#login" className="hover:underline">
-                  ログイン
-                </Link>
-              </NavigationMenuItem>
-            </NavigationMenuList>
-          </NavigationMenu>
-          <div className="md:hidden">
-            <button onClick={() => setMenuOpen(!menuOpen)} className="transition-transform duration-200">
-              {menuOpen ? <X size={24} /> : <Menu size={24} />}
-            </button>
-          </div>
+            <Link href="#category" className="hover:underline">
+              カテゴリ
+            </Link>
+            <Link href="/login" className="hover:underline">
+              ログイン
+            </Link>
+          </nav>
         </div>
-        <div
-          className={`md:hidden overflow-hidden transition-all duration-300 ease-in-out ${
-            menuOpen ? "max-h-60 opacity-100 py-4" : "max-h-0 opacity-0 py-0"
-          } bg-white px-6`}
-        >
-          <ul className="space-y-4 text-base">
-            <li>
-              <Link href="#top" onClick={() => setMenuOpen(false)}>
-                サービス
-              </Link>
-            </li>
-            <li>
-              <Link href="#projects" onClick={() => setMenuOpen(false)}>
-                実績
-              </Link>
-            </li>
-            <li>
-              <Link href="#contact" onClick={() => setMenuOpen(false)}>
-                お問い合わせ
-              </Link>
-            </li>
-          </ul>
+        <div className="bg-zinc-800 text-white">
+          <div className="max-w-7xl mx-auto px-4 py-2">
+            <Tabs value={activeTab} onValueChange={setActiveTab}>
+              <TabsList className="mb-2">
+                <TabsTrigger value="tool" className="capitalize">
+                  tool
+                </TabsTrigger>
+                <TabsTrigger value="template" className="capitalize">
+                  template
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent value="tool">
+                <div className="flex flex-wrap gap-2">
+                  {toolCategories.map((c) => (
+                    <CategoryButton key={c} label={c} />
+                  ))}
+                </div>
+              </TabsContent>
+              <TabsContent value="template">
+                <div className="flex flex-wrap gap-2">
+                  {templateCategories.map((c) => (
+                    <CategoryButton key={c} label={c} />
+                  ))}
+                </div>
+              </TabsContent>
+            </Tabs>
+          </div>
         </div>
       </div>
-      <nav className="bg-neutral-800 py-3">
-        <div className="flex justify-center gap-12">
-          <div>
-            <p className="text-white text-sm mb-1">tool</p>
-            <ul className="flex gap-4">
-              {toolCategories.map((category) => (
-                <li key={category}>
-                  <Link
-                    href={`/product/category/${encodeURIComponent(category)}`}
-                    className="text-white text-lg hover:underline transition"
-                  >
-                    {category}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div>
-            <p className="text-white text-sm mb-1">template</p>
-            <ul className="flex gap-4">
-              {templateCategories.map((category) => (
-                <li key={category}>
-                  <Link
-                    href={`/product/category/${encodeURIComponent(category)}`}
-                    className="text-white text-lg hover:underline transition"
-                  >
-                    {category}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      </nav>
     </header>
   );
 }

--- a/app/components/product/ProductForm.tsx
+++ b/app/components/product/ProductForm.tsx
@@ -167,27 +167,50 @@ export function ProductForm({ defaultValues, id }: Props) {
             </FormItem>
           )}
         />
-        <FormField
-          control={form.control}
-          name="type"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>種類</FormLabel>
-              <FormControl>
-                <Select value={field.value} onValueChange={field.onChange}>
-                  <SelectTrigger className="max-w-md bg-white hover:bg-gray-50">
-                    <SelectValue placeholder="選択" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="TOOL">tool</SelectItem>
-                    <SelectItem value="TEMPLATE">template</SelectItem>
-                  </SelectContent>
-                </Select>
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        <div className="flex flex-col sm:flex-row gap-4">
+          <FormField
+            control={form.control}
+            name="type"
+            render={({ field }) => (
+              <FormItem className="w-full sm:w-1/2">
+                <FormLabel>種類</FormLabel>
+                <FormControl>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger className="w-full bg-white hover:bg-gray-50">
+                      <SelectValue placeholder="選択" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="TOOL">tool</SelectItem>
+                      <SelectItem value="TEMPLATE">template</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="deliveryType"
+            render={({ field }) => (
+              <FormItem className="w-full sm:w-1/2">
+                <FormLabel>配布方法</FormLabel>
+                <FormControl>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger className="w-full bg-white hover:bg-gray-50">
+                      <SelectValue placeholder="選択" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="FILE">FILE</SelectItem>
+                      <SelectItem value="URL">URL</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
         <FormField
           control={form.control}
           name="category"
@@ -222,27 +245,6 @@ export function ProductForm({ defaultValues, id }: Props) {
               <FormLabel>説明</FormLabel>
               <FormControl>
                 <Textarea rows={5} {...field} className="max-w-md" />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="deliveryType"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>配布方法</FormLabel>
-              <FormControl>
-                <Select value={field.value} onValueChange={field.onChange}>
-                  <SelectTrigger className="max-w-md bg-white hover:bg-gray-50">
-                    <SelectValue placeholder="選択" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="FILE">FILE</SelectItem>
-                    <SelectItem value="URL">URL</SelectItem>
-                  </SelectContent>
-                </Select>
               </FormControl>
               <FormMessage />
             </FormItem>


### PR DESCRIPTION
## Summary
- horizontally align "種類" and "配布方法" fields in `ProductForm`
- redesign product header with two-layer navigation
- add `CategoryButton` component for header categories

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688642ed876c8328966238e9d7b09b0c