### PR TITLE
Unify header layout

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
 import {
   NavigationMenu,
   NavigationMenuItem,
@@ -11,12 +12,13 @@ import Image from "next/image";
 import { Menu, X } from "lucide-react";
 
 export function Header() {
-  const [scrolled, setScrolled] = useState(false);
+  const [hideHeader, setHideHeader] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+  const pathname = usePathname();
 
   useEffect(() => {
     const handleScroll = () => {
-      setScrolled(window.scrollY > 50);
+      setHideHeader(window.scrollY > 80);
     };
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
@@ -24,14 +26,13 @@ export function Header() {
 
   return (
     <header
-      className={`fixed top-0 left-0 w-full z-50 transition-all duration-300 ${
-        scrolled
-          ? "bg-white/80 backdrop-blur-md shadow-md border-b"
-          : "bg-transparent"
-      } ${scrolled ? "py-2" : "py-4"}`}
+      className={`fixed top-0 left-0 w-full z-50 transition-transform duration-300 ${
+        hideHeader ? "-translate-y-full" : "translate-y-0"
+      }`}
     >
-      <div className="max-w-7xl mx-auto flex items-center justify-between px-4">
-        <Link href="/" className="text-xl font-bold">
+      <div className="border-b bg-white shadow-sm">
+        <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-3">
+        <Link href="/" className="flex items-center gap-2 text-lg font-bold">
           <Image
             src={SimproSvg}
             alt="Simpro Logo"
@@ -60,14 +61,28 @@ export function Header() {
               </Link>
             </NavigationMenuItem>
             <NavigationMenuItem>
-              <Link href="/blog" className="hover:underline">
+              <Link
+                href="/blog"
+                className={
+                  pathname.startsWith("/blog")
+                    ? "text-blue-600"
+                    : "hover:underline"
+                }
+              >
                 Blog
               </Link>
             </NavigationMenuItem>
             <NavigationMenuItem>
-            <Link href="/product" className="hover:underline">
-              Product
-            </Link>
+              <Link
+                href="/product"
+                className={
+                  pathname.startsWith("/product")
+                    ? "text-blue-600"
+                    : "hover:underline"
+                }
+              >
+                Product
+              </Link>
             </NavigationMenuItem>
             {/* <NavigationMenuItem>
               <Link href="/template" className="hover:underline">
@@ -111,12 +126,20 @@ export function Header() {
             </Link>
           </li>
           <li>
-            <Link href="/blog" onClick={() => setMenuOpen(false)}>
+            <Link
+              href="/blog"
+              onClick={() => setMenuOpen(false)}
+              className={pathname.startsWith("/blog") ? "text-blue-600" : ""}
+            >
               Blog
             </Link>
           </li>
           <li>
-            <Link href="/product" onClick={() => setMenuOpen(false)}>
+            <Link
+              href="/product"
+              onClick={() => setMenuOpen(false)}
+              className={pathname.startsWith("/product") ? "text-blue-600" : ""}
+            >
               Product
             </Link>
           </li>
@@ -126,6 +149,7 @@ export function Header() {
             </Link>
           </li> */}
         </ul>
+      </div>
       </div>
     </header>
   );

--- a/app/components/HeaderBlog.tsx
+++ b/app/components/HeaderBlog.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
 import {
   NavigationMenu,
   NavigationMenuItem,
@@ -16,6 +17,7 @@ export function HeaderBlog() {
   const [hideHeader, setHideHeader] = useState(false);
   const [lastScrollY, setLastScrollY] = useState(0);
   const [menuOpen, setMenuOpen] = useState(false);
+  const pathname = usePathname();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -34,10 +36,10 @@ export function HeaderBlog() {
       }`}
     >
       {/* 上段: 白背景（ロゴ + メニュー） */}
-      <div className="bg-white shadow">
-        <div className="container mx-auto flex items-center justify-between px-4 py-4">
+      <div className="border-b bg-white shadow-sm">
+        <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-3">
           <div className="flex items-center gap-2">
-            <Link href="/" className="text-xl font-bold">
+            <Link href="/" className="flex items-center gap-2 text-lg font-bold">
               <Image
                 src={SimproSvg}
                 alt="Simpro Logo"
@@ -46,14 +48,19 @@ export function HeaderBlog() {
                 priority
               />
             </Link>
-            <p className="text-black text-xl"> - Blog</p>
+            <span className="text-blue-600 text-lg">- Blog</span>
           </div>
 
           {/* Desktopメニュー */}
           <NavigationMenu className="hidden md:block">
-            <NavigationMenuList className="space-x-6">
+            <NavigationMenuList className="space-x-6 text-sm font-medium">
               <NavigationMenuItem>
-                <Link href="#top" className="hover:underline">
+                <Link
+                  href="#top"
+                  className={
+                    pathname.startsWith("/blog") ? "text-blue-600" : "hover:underline"
+                  }
+                >
                   TOP
                 </Link>
               </NavigationMenuItem>
@@ -89,18 +96,22 @@ export function HeaderBlog() {
         >
           <ul className="space-y-4 text-base">
             <li>
-              <Link href="#top" onClick={() => setMenuOpen(false)}>
-                サービス
+              <Link
+                href="#top"
+                onClick={() => setMenuOpen(false)}
+                className={pathname.startsWith("/blog") ? "text-blue-600" : ""}
+              >
+                TOP
               </Link>
             </li>
             <li>
-              <Link href="#projects" onClick={() => setMenuOpen(false)}>
-                実績
+              <Link href="#category" onClick={() => setMenuOpen(false)}>
+                カテゴリ
               </Link>
             </li>
             <li>
-              <Link href="#contact" onClick={() => setMenuOpen(false)}>
-                お問い合わせ
+              <Link href="#login" onClick={() => setMenuOpen(false)}>
+                ログイン
               </Link>
             </li>
           </ul>

--- a/app/components/HeaderProduct.tsx
+++ b/app/components/HeaderProduct.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
 import SimproSvg from "@/public/Simplo_gray_main_sub.svg";
@@ -12,6 +13,7 @@ const templateCategories = ["Webサイトテンプレート", "Webアプリテ�
 export function HeaderProduct() {
   const [hideHeader, setHideHeader] = useState(false);
   const [activeTab, setActiveTab] = useState("tool");
+  const pathname = usePathname();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -30,17 +32,25 @@ export function HeaderProduct() {
         <div className="max-w-7xl mx-auto flex justify-between items-center px-4 py-3">
           <Link href="/" className="flex items-center gap-2 text-lg font-bold">
             <Image src={SimproSvg} alt="Simpro Logo" width={100} height={40} priority />
-            <span className="text-black">- Products</span>
+            <span className="text-blue-600">- Products</span>
           </Link>
           <div className="flex-1 mx-4 hidden md:block" />
           <nav className="flex gap-6 text-sm font-medium">
-            <Link href="/" className="hover:underline">
+            <Link
+              href="/"
+              className={pathname === "/" ? "text-blue-600" : "hover:underline"}
+            >
               TOP
             </Link>
             <Link href="#category" className="hover:underline">
               カテゴリ
             </Link>
-            <Link href="/login" className="hover:underline">
+            <Link
+              href="/login"
+              className={
+                pathname.startsWith("/login") ? "text-blue-600" : "hover:underline"
+              }
+            >
               ログイン
             </Link>
           </nav>


### PR DESCRIPTION
## Summary
- unify landing, blog, and product headers based on the product layout
- mark active page links with blue color

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68883c07cc6c83289458cddf4f4d0d77