### PR TITLE
Add dropdown navigation and product category pages

### DIFF
--- a/app/(landing)/page.tsx
+++ b/app/(landing)/page.tsx
@@ -1,4 +1,4 @@
-import { Header } from "@/app/components/Header";
+import { Header } from "@/components/navigation/Header";
 import { HeroSection } from "@/app/components/HeroSection";
 import { ServicesSection } from "@/app/components/ServicesSection";
 import { ProjectsSlider } from "@/app/components/ProjectsSlider";

--- a/app/products/[type]/[subtype]/page.tsx
+++ b/app/products/[type]/[subtype]/page.tsx
@@ -1,0 +1,27 @@
+import { ProductGrid } from '@/app/components/product/ProductGrid'
+import { getProductsByTypeAndCategory } from '@/lib/product'
+import { CategoryTabs } from '@/components/products/CategoryTabs'
+import { SubCategoryTags } from '@/components/products/SubCategoryTags'
+
+export default async function ProductSubCategoryPage({
+  params,
+}: {
+  params: { type: string; subtype: string }
+}) {
+  const { type, subtype } = params
+  const products = await getProductsByTypeAndCategory(type.toUpperCase(), decodeURIComponent(subtype))
+
+  return (
+    <section className="px-4 sm:px-8 md:px-16 lg:px-20 py-4 mt-8">
+      <CategoryTabs />
+      <SubCategoryTags type={type} />
+      <div className="mt-6">
+        {products.length > 0 ? (
+          <ProductGrid tools={products} />
+        ) : (
+          <p className="text-gray-600">準備中...</p>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/app/products/layout.tsx
+++ b/app/products/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next'
+import { Header } from '@/components/navigation/Header'
+import { Footer } from '@/app/components/Footer'
+
+export const metadata: Metadata = {
+  title: 'Products',
+  description: 'Product distribution',
+}
+
+export default function ProductsLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <main className="flex-grow mt-[130px]">{children}</main>
+      <Footer />
+    </div>
+  )
+}

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -1,0 +1,17 @@
+import { getPublishedProducts } from '@/lib/product'
+import { CategoryTabs } from '@/components/products/CategoryTabs'
+import { SubCategoryTags } from '@/components/products/SubCategoryTags'
+import { ProductGrid } from '@/app/components/product/ProductGrid'
+
+export default async function ProductsPage() {
+  const products = await getPublishedProducts()
+  return (
+    <section className="px-4 sm:px-8 md:px-16 lg:px-20 py-4 mt-8">
+      <CategoryTabs />
+      <SubCategoryTags type="tool" />
+      <div className="mt-6">
+        <ProductGrid tools={products} />
+      </div>
+    </section>
+  )
+}

--- a/components/navigation/DropdownNav.tsx
+++ b/components/navigation/DropdownNav.tsx
@@ -1,0 +1,58 @@
+'use client'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuTrigger,
+  NavigationMenuContent,
+  NavigationMenuLink
+} from '@/components/ui/navigation-menu'
+import type { NavItem } from '@/data/navigation'
+
+export function DropdownNav({ items }: { items: NavItem[] }) {
+  const pathname = usePathname()
+  return (
+    <NavigationMenu>
+      <NavigationMenuList className="space-x-8 font-medium tracking-wide">
+        {items.map((item) =>
+          item.children ? (
+            <NavigationMenuItem key={item.title}>
+              <NavigationMenuTrigger
+                className={pathname.startsWith(item.href) ? 'underline decoration-blue-500' : ''}
+              >
+                {item.title}
+              </NavigationMenuTrigger>
+              <NavigationMenuContent>
+                <ul className="min-w-[150px] bg-white p-2 shadow-md rounded-md">
+                  {item.children.map((child) => (
+                    <li key={child.href}>
+                      <NavigationMenuLink asChild>
+                        <Link
+                          href={child.href}
+                          className="block px-3 py-2 hover:bg-blue-50 whitespace-nowrap"
+                        >
+                          {child.title}
+                        </Link>
+                      </NavigationMenuLink>
+                    </li>
+                  ))}
+                </ul>
+              </NavigationMenuContent>
+            </NavigationMenuItem>
+          ) : (
+            <NavigationMenuItem key={item.title}>
+              <Link
+                href={item.href}
+                className={`hover:underline ${pathname === item.href ? 'underline decoration-blue-500' : ''}`}
+              >
+                {item.title}
+              </Link>
+            </NavigationMenuItem>
+          )
+        )}
+      </NavigationMenuList>
+    </NavigationMenu>
+  )
+}

--- a/components/navigation/Header.tsx
+++ b/components/navigation/Header.tsx
@@ -1,0 +1,75 @@
+'use client'
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+import { Menu, X } from 'lucide-react'
+import SimproSvg from '@/public/Simplo_gray_main_sub.svg'
+import { DropdownNav } from './DropdownNav'
+import { navigation } from '@/data/navigation'
+
+export function Header() {
+  const [hideHeader, setHideHeader] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setHideHeader(window.scrollY > 80)
+    }
+    window.addEventListener('scroll', handleScroll)
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [])
+
+  return (
+    <header
+      className={`fixed top-0 left-0 w-full z-50 transition-transform duration-300 ${
+        hideHeader ? '-translate-y-full' : 'translate-y-0'
+      }`}
+    >
+      <div className="bg-white shadow-sm">
+        <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-3">
+          <Link href="/" className="flex items-center gap-2 text-lg font-bold">
+            <Image src={SimproSvg} alt="Simpro Logo" width={100} height={40} priority />
+          </Link>
+          <div className="hidden md:block">
+            <DropdownNav items={navigation} />
+          </div>
+          <div className="md:hidden">
+            <button onClick={() => setMenuOpen(!menuOpen)} className="transition-transform duration-200">
+              {menuOpen ? <X size={24} /> : <Menu size={24} />}
+            </button>
+          </div>
+        </div>
+        <div
+          className={`md:hidden overflow-hidden transition-all duration-300 ease-in-out ${
+            menuOpen ? 'max-h-60 opacity-100 py-4' : 'max-h-0 opacity-0 py-0'
+          } bg-white/90 backdrop-blur-md px-6`}
+        >
+          <ul className="space-y-4 text-base">
+            {navigation.map((item) => (
+              <li key={item.title} className="space-y-2">
+                {item.children ? (
+                  <details>
+                    <summary className="cursor-pointer">{item.title}</summary>
+                    <ul className="mt-2 pl-4 space-y-1">
+                      {item.children.map((child) => (
+                        <li key={child.href}>
+                          <Link href={child.href} onClick={() => setMenuOpen(false)}>
+                            {child.title}
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </details>
+                ) : (
+                  <Link href={item.href} onClick={() => setMenuOpen(false)}>
+                    {item.title}
+                  </Link>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/components/products/CategoryTabs.tsx
+++ b/components/products/CategoryTabs.tsx
@@ -1,0 +1,27 @@
+'use client'
+import Link from 'next/link'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { usePathname } from 'next/navigation'
+
+export function CategoryTabs() {
+  const pathname = usePathname()
+  const segments = pathname.split('/')
+  const type = segments[2] || 'tool'
+
+  return (
+    <Tabs value={type} className="mb-4">
+      <TabsList className="justify-start gap-2">
+        <TabsTrigger value="tool" asChild>
+          <Link href="/products/tool/webtool" className="capitalize">
+            tool
+          </Link>
+        </TabsTrigger>
+        <TabsTrigger value="template" asChild>
+          <Link href="/products/template/web" className="capitalize">
+            template
+          </Link>
+        </TabsTrigger>
+      </TabsList>
+    </Tabs>
+  )
+}

--- a/components/products/SubCategoryTags.tsx
+++ b/components/products/SubCategoryTags.tsx
@@ -1,0 +1,33 @@
+'use client'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { usePathname } from 'next/navigation'
+
+const toolCategories = ['webtool', 'gas', 'vba', 'exe']
+const templateCategories = ['web', 'app']
+
+export function SubCategoryTags({ type }: { type: string }) {
+  const pathname = usePathname()
+  const segments = pathname.split('/')
+  const current = segments[3] || ''
+  const categories = type === 'template' ? templateCategories : toolCategories
+
+  return (
+    <div className="flex flex-wrap gap-3">
+      {categories.map((c) => {
+        const active = c === current
+        return (
+          <Button
+            key={c}
+            asChild
+            variant={active ? 'secondary' : 'outline'}
+            size="sm"
+            className={active ? 'bg-blue-600 text-white border-blue-600' : ''}
+          >
+            <Link href={`/products/${type}/${c}`}>{c}</Link>
+          </Button>
+        )
+      })}
+    </div>
+  )
+}

--- a/data/navigation.ts
+++ b/data/navigation.ts
@@ -1,0 +1,30 @@
+export type NavItem = {
+  title: string
+  href: string
+  children?: { title: string; href: string }[]
+}
+
+export const navigation: NavItem[] = [
+  { title: 'サービス', href: '/#services' },
+  { title: '実績', href: '/#projects' },
+  { title: 'お問い合わせ', href: '/#contact' },
+  {
+    title: 'Blog',
+    href: '/blog',
+    children: [
+      { title: 'Skill', href: '/blog/category/Skill' },
+      { title: 'Book', href: '/blog/category/Book' },
+      { title: 'Job', href: '/blog/category/Job' },
+      { title: 'Life', href: '/blog/category/Life' },
+      { title: 'Design', href: '/blog/category/Design' }
+    ]
+  },
+  {
+    title: 'Products',
+    href: '/products',
+    children: [
+      { title: 'Tool', href: '/products/tool/webtool' },
+      { title: 'Template', href: '/products/template/web' }
+    ]
+  }
+]

--- a/lib/product.ts
+++ b/lib/product.ts
@@ -46,3 +46,13 @@ export async function getProductsByCategory(category: string): Promise<Product[]
   const products = await getPublishedProducts();
   return products.filter((c) => c.category === category).map(mapRecordToProduct);
 }
+
+export async function getProductsByTypeAndCategory(
+  type: string,
+  category: string
+): Promise<Product[]> {
+  const records = await fetchPublishedProducts();
+  return records
+    .filter((r) => r.type === type && r.category === category)
+    .map(mapRecordToProduct);
+}


### PR DESCRIPTION
## Summary
- implement dropdown global navigation using data/navigation
- add header component for navigation
- add product category UI with tabs and tags
- create dynamic product pages for type/category
- expose helper to fetch products by type and category

## Testing
- `npm run lint` *(fails: `next: not found` due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6888e7d2e4b8832891334aa02584fcb6