### PR TITLE
Refine header layout for product categories

### DIFF
--- a/app/components/HeaderProduct.tsx
+++ b/app/components/HeaderProduct.tsx
@@ -57,35 +57,39 @@ export function HeaderProduct() {
         </div>
         <div className="bg-zinc-800 text-white">
           <div className="max-w-7xl mx-auto px-4 py-3">
-            <Tabs value={activeTab} onValueChange={setActiveTab}>
-              <TabsList className="mb-3 justify-start gap-2">
-                <TabsTrigger
-                  value="tool"
-                  className="capitalize data-[state=active]:bg-white data-[state=active]:text-zinc-800"
-                >
-                  tool
-                </TabsTrigger>
-                <TabsTrigger
-                  value="template"
-                  className="capitalize data-[state=active]:bg-white data-[state=active]:text-zinc-800"
-                >
-                  template
-                </TabsTrigger>
-              </TabsList>
-              <TabsContent value="tool">
-                <div className="flex flex-wrap gap-3">
-                  {toolCategories.map((c) => (
-                    <CategoryButton key={c} label={c} />
-                  ))}
+            <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-start gap-4 w-full">
+                <TabsList className="flex gap-2">
+                  <TabsTrigger
+                    value="tool"
+                    className="capitalize data-[state=active]:text-blue-600 data-[state=active]:font-bold"
+                  >
+                    tool
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="template"
+                    className="capitalize data-[state=active]:text-blue-600 data-[state=active]:font-bold"
+                  >
+                    template
+                  </TabsTrigger>
+                </TabsList>
+                <div className="flex-1 sm:ml-6">
+                  <TabsContent value="tool" className="sm:mt-0 mt-2">
+                    <div className="flex flex-wrap gap-3">
+                      {toolCategories.map((c) => (
+                        <CategoryButton key={c} label={c} />
+                      ))}
+                    </div>
+                  </TabsContent>
+                  <TabsContent value="template" className="sm:mt-0 mt-2">
+                    <div className="flex flex-wrap gap-3">
+                      {templateCategories.map((c) => (
+                        <CategoryButton key={c} label={c} />
+                      ))}
+                    </div>
+                  </TabsContent>
                 </div>
-              </TabsContent>
-              <TabsContent value="template">
-                <div className="flex flex-wrap gap-3">
-                  {templateCategories.map((c) => (
-                    <CategoryButton key={c} label={c} />
-                  ))}
-                </div>
-              </TabsContent>
+              </div>
             </Tabs>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- adjust product header layout to place Tool and Template tabs on the left
- show subcategories to the right of the active tab
- highlight active tab in blue and bold

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b6a0984888328a5f56eb5fa0dce72