### PR TITLE
Add type-specific product category pages

### DIFF
--- a/app/components/CategoryButton.tsx
+++ b/app/components/CategoryButton.tsx
@@ -2,7 +2,13 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
-export function CategoryButton({ label }: { label: string }) {
+export function CategoryButton({
+  label,
+  type,
+}: {
+  label: string;
+  type: "tool" | "template";
+}) {
   return (
     <Button
       asChild
@@ -10,7 +16,7 @@ export function CategoryButton({ label }: { label: string }) {
       size="sm"
       className="bg-white text-zinc-800 hover:bg-zinc-100 shadow"
     >
-      <Link href={`/product/category/${encodeURIComponent(label)}`}>{label}</Link>
+      <Link href={`/product/${type}/${encodeURIComponent(label)}`}>{label}</Link>
     </Button>
   );
 }

--- a/app/components/HeaderProduct.tsx
+++ b/app/components/HeaderProduct.tsx
@@ -77,14 +77,14 @@ export function HeaderProduct() {
                   <TabsContent value="tool" className="sm:mt-0 mt-2">
                     <div className="flex flex-wrap gap-3">
                       {toolCategories.map((c) => (
-                        <CategoryButton key={c} label={c} />
+                        <CategoryButton key={c} label={c} type="tool" />
                       ))}
                     </div>
                   </TabsContent>
                   <TabsContent value="template" className="sm:mt-0 mt-2">
                     <div className="flex flex-wrap gap-3">
                       {templateCategories.map((c) => (
-                        <CategoryButton key={c} label={c} />
+                        <CategoryButton key={c} label={c} type="template" />
                       ))}
                     </div>
                   </TabsContent>

--- a/app/components/product/ProductBreadcrumbs.tsx
+++ b/app/components/product/ProductBreadcrumbs.tsx
@@ -12,6 +12,7 @@ import {
 interface BreadcrumbsProps {
   category?: string;
   title?: string;
+  type?: "tool" | "template";
 }
 
 type Crumb = {
@@ -19,16 +20,17 @@ type Crumb = {
   href?: string;
 };
 
-export function ProductBreadcrumbs({ category, title }: BreadcrumbsProps) {
+export function ProductBreadcrumbs({ category, title, type }: BreadcrumbsProps) {
   const items: Crumb[] = [
     { name: "Home", href: "/" },
     { name: "Products", href: "/product" },
   ];
 
   if (category) {
+    const base = type ? `/product/${type}` : "/product/category";
     items.push({
       name: category,
-      href: `/product/category/${encodeURIComponent(category)}`,
+      href: `${base}/${encodeURIComponent(category)}`,
     });
   }
 

--- a/app/product/[slug]/page.tsx
+++ b/app/product/[slug]/page.tsx
@@ -25,14 +25,21 @@ export default async function ProductDetailPage({
   const breadcrumbItems = [
     { name: "Home", url: `${baseUrl}/` },
     { name: "Products", url: `${baseUrl}/product` },
-    { name: product.category, url: `${baseUrl}/product/category/${encodeURIComponent(product.category)}` },
+    {
+      name: product.category,
+      url: `${baseUrl}/product/${product.type}/${encodeURIComponent(product.category)}`,
+    },
     { name: product.title },
   ];
   const jsonLd = generateBreadcrumbJsonLd(breadcrumbItems);
 
   return (
     <div className="px-20 py-4 mt-8">
-      <ProductBreadcrumbs category={product.category} title={product.title} />
+      <ProductBreadcrumbs
+        type={product.type}
+        category={product.category}
+        title={product.title}
+      />
       <div className="max-w-3xl mx-auto py-12">
         <Script id="breadcrumb-product-jsonld" type="application/ld+json">
           {JSON.stringify(jsonLd)}

--- a/app/product/template/[category]/page.tsx
+++ b/app/product/template/[category]/page.tsx
@@ -1,0 +1,44 @@
+import { ProductGrid } from "@/app/components/product/ProductGrid";
+import { getProductsByTypeAndCategory } from "@/lib/product";
+import { notFound } from "next/navigation";
+import { ProductBreadcrumbs } from "@/app/components/product/ProductBreadcrumbs";
+import { generateBreadcrumbJsonLd } from "@/lib/seo/breadcrumb";
+import Script from "next/script";
+
+export default async function ProductCategoryPage({
+  params,
+}: {
+  params: Promise<{ category: string }> | { category: string };
+}) {
+  const { category: raw } = await params;
+  const category = decodeURIComponent(raw);
+  const products = await getProductsByTypeAndCategory("TEMPLATE", category);
+
+  if (products.length === 0) {
+    notFound();
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? "";
+  const breadcrumbItems = [
+    { name: "Home", url: `${baseUrl}/` },
+    { name: "Products", url: `${baseUrl}/product` },
+    { name: category },
+  ];
+  const jsonLd = generateBreadcrumbJsonLd(breadcrumbItems);
+
+  return (
+    <section className="px-20 py-4 mt-8">
+      <Script id="breadcrumb-product-category-jsonld" type="application/ld+json">
+        {JSON.stringify(jsonLd)}
+      </Script>
+
+      <ProductBreadcrumbs type="template" category={category} title="" />
+      <h1 className="py-4 mt-4 text-2xl text-gray-800">
+        プロダクト一覧<span>（{category}）</span>
+      </h1>
+      <div className="py-2">
+        <ProductGrid tools={products} />
+      </div>
+    </section>
+  );
+}

--- a/app/product/tool/[category]/page.tsx
+++ b/app/product/tool/[category]/page.tsx
@@ -1,0 +1,44 @@
+import { ProductGrid } from "@/app/components/product/ProductGrid";
+import { getProductsByTypeAndCategory } from "@/lib/product";
+import { notFound } from "next/navigation";
+import { ProductBreadcrumbs } from "@/app/components/product/ProductBreadcrumbs";
+import { generateBreadcrumbJsonLd } from "@/lib/seo/breadcrumb";
+import Script from "next/script";
+
+export default async function ProductCategoryPage({
+  params,
+}: {
+  params: Promise<{ category: string }> | { category: string };
+}) {
+  const { category: raw } = await params;
+  const category = decodeURIComponent(raw);
+  const products = await getProductsByTypeAndCategory("TOOL", category);
+
+  if (products.length === 0) {
+    notFound();
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? "";
+  const breadcrumbItems = [
+    { name: "Home", url: `${baseUrl}/` },
+    { name: "Products", url: `${baseUrl}/product` },
+    { name: category },
+  ];
+  const jsonLd = generateBreadcrumbJsonLd(breadcrumbItems);
+
+  return (
+    <section className="px-20 py-4 mt-8">
+      <Script id="breadcrumb-product-category-jsonld" type="application/ld+json">
+        {JSON.stringify(jsonLd)}
+      </Script>
+
+      <ProductBreadcrumbs type="tool" category={category} title="" />
+      <h1 className="py-4 mt-4 text-2xl text-gray-800">
+        プロダクト一覧<span>（{category}）</span>
+      </h1>
+      <div className="py-2">
+        <ProductGrid tools={products} />
+      </div>
+    </section>
+  );
+}

--- a/lib/product.ts
+++ b/lib/product.ts
@@ -15,6 +15,7 @@ function mapRecordToProduct(item: ProductRecord): Product {
     : '/Simplo_gray_main_sub.jpg';
 
   return {
+    type: item.type.toLowerCase() as 'tool' | 'template',
     title: item.title,
     category: item.category,
     description: item.description ?? '',
@@ -44,7 +45,7 @@ export async function getProductBySlug(slug: string): Promise<Product | undefine
 
 export async function getProductsByCategory(category: string): Promise<Product[]> {
   const products = await getPublishedProducts();
-  return products.filter((c) => c.category === category).map(mapRecordToProduct);
+  return products.filter((c) => c.category === category);
 }
 
 export async function getProductsByTypeAndCategory(

--- a/types/product.ts
+++ b/types/product.ts
@@ -1,4 +1,5 @@
 export type Product = {
+  type: "tool" | "template";
   title: string;
   category: string;
   description: string;


### PR DESCRIPTION
## Summary
- extend `Product` type with `type` and map it in product utilities
- update breadcrumbs to support type-specific category paths
- update category button logic to include product type
- link category buttons from the header to new paths
- add new pages for tool and template category details
- adjust existing product detail page to use new breadcrumbs
- fix `getProductsByCategory` implementation

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688b748a783883288165c680d75672f4