### PR TITLE
Update category page routing

### DIFF
--- a/app/components/CategoryButton.tsx
+++ b/app/components/CategoryButton.tsx
@@ -2,7 +2,13 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
-export function CategoryButton({ label }: { label: string }) {
+export function CategoryButton({
+  label,
+  type,
+}: {
+  label: string;
+  type: string;
+}) {
   return (
     <Button
       asChild
@@ -10,7 +16,7 @@ export function CategoryButton({ label }: { label: string }) {
       size="sm"
       className="bg-white text-zinc-800 hover:bg-zinc-100 shadow"
     >
-      <Link href={`/product/category/${encodeURIComponent(label)}`}>{label}</Link>
+      <Link href={`/product/${type}/${encodeURIComponent(label)}`}>{label}</Link>
     </Button>
   );
 }

--- a/app/components/HeaderProduct.tsx
+++ b/app/components/HeaderProduct.tsx
@@ -77,14 +77,14 @@ export function HeaderProduct() {
                   <TabsContent value="tool" className="sm:mt-0 mt-2">
                     <div className="flex flex-wrap gap-3">
                       {toolCategories.map((c) => (
-                        <CategoryButton key={c} label={c} />
+                        <CategoryButton key={c} type="tool" label={c} />
                       ))}
                     </div>
                   </TabsContent>
                   <TabsContent value="template" className="sm:mt-0 mt-2">
                     <div className="flex flex-wrap gap-3">
                       {templateCategories.map((c) => (
-                        <CategoryButton key={c} label={c} />
+                        <CategoryButton key={c} type="template" label={c} />
                       ))}
                     </div>
                   </TabsContent>

--- a/app/components/product/ProductBreadcrumbs.tsx
+++ b/app/components/product/ProductBreadcrumbs.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/breadcrumb";
 
 interface BreadcrumbsProps {
+  type?: string;
   category?: string;
   title?: string;
 }
@@ -19,17 +20,19 @@ type Crumb = {
   href?: string;
 };
 
-export function ProductBreadcrumbs({ category, title }: BreadcrumbsProps) {
+export function ProductBreadcrumbs({ type, category, title }: BreadcrumbsProps) {
   const items: Crumb[] = [
     { name: "Home", href: "/" },
     { name: "Products", href: "/product" },
   ];
 
-  if (category) {
+  if (type && category) {
     items.push({
       name: category,
-      href: `/product/category/${encodeURIComponent(category)}`,
+      href: `/product/${type}/${encodeURIComponent(category)}`,
     });
+  } else if (category) {
+    items.push({ name: category });
   }
 
   if (title) {

--- a/app/product/[slug]/page.tsx
+++ b/app/product/[slug]/page.tsx
@@ -25,7 +25,7 @@ export default async function ProductDetailPage({
   const breadcrumbItems = [
     { name: "Home", url: `${baseUrl}/` },
     { name: "Products", url: `${baseUrl}/product` },
-    { name: product.category, url: `${baseUrl}/product/category/${encodeURIComponent(product.category)}` },
+    { name: product.category },
     { name: product.title },
   ];
   const jsonLd = generateBreadcrumbJsonLd(breadcrumbItems);

--- a/app/product/[type]/[category]/page.tsx
+++ b/app/product/[type]/[category]/page.tsx
@@ -1,0 +1,62 @@
+import { ProductGrid } from "@/app/components/product/ProductGrid";
+import { getProductsByTypeAndCategory } from "@/lib/product";
+import { ProductBreadcrumbs } from "@/app/components/product/ProductBreadcrumbs";
+import { generateBreadcrumbJsonLd } from "@/lib/seo/breadcrumb";
+import { categoryDetails } from "@/data/categoryDetails";
+import Image from "next/image";
+import Script from "next/script";
+import { notFound } from "next/navigation";
+
+export default async function ProductTypeCategoryPage({
+  params,
+}: {
+  params: { type: string; category: string };
+}) {
+  const { type, category: raw } = params;
+  const category = decodeURIComponent(raw);
+  const products = await getProductsByTypeAndCategory(type.toUpperCase(), category);
+
+  const detail = categoryDetails[type]?.[category];
+
+  if (!detail && products.length === 0) {
+    notFound();
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? "";
+  const breadcrumbItems = [
+    { name: "Home", url: `${baseUrl}/` },
+    { name: "Products", url: `${baseUrl}/product` },
+    { name: category },
+  ];
+  const jsonLd = generateBreadcrumbJsonLd(breadcrumbItems);
+
+  return (
+    <section className="px-20 py-4 mt-8 space-y-6">
+      <Script id="breadcrumb-product-category-jsonld" type="application/ld+json">
+        {JSON.stringify(jsonLd)}
+      </Script>
+
+      <ProductBreadcrumbs type={type} category={category} title="" />
+      <h1 className="text-2xl text-gray-800">プロダクト一覧<span>（{category}）</span></h1>
+      {detail && (
+        <div className="flex flex-col items-center text-center gap-4">
+          <Image
+            src={detail.image}
+            alt={category}
+            width={600}
+            height={400}
+            className="w-full max-w-xl h-64 object-cover rounded-lg"
+          />
+          <p className="text-gray-700 leading-relaxed max-w-2xl">{detail.description}</p>
+        </div>
+      )}
+      <div className="py-2">
+        {products.length > 0 ? (
+          <ProductGrid tools={products} />
+        ) : (
+          <p className="text-gray-600">準備中...</p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/data/categoryDetails.ts
+++ b/data/categoryDetails.ts
@@ -1,0 +1,19 @@
+export type CategoryDetail = {
+  description: string;
+  image: string;
+};
+
+export const categoryDetails: Record<string, Record<string, CategoryDetail>> = {
+  tool: {
+    "Executable File": {
+      description: "OS上で直接実行できる便利なツールをまとめています。",
+      image: "/Simplo_gray_main_sub.jpg",
+    },
+  },
+  template: {
+    "Webテンプレート": {
+      description: "ウェブサイト制作に役立つテンプレート集です。",
+      image: "/Simplo_gray_main_sub.jpg",
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- add static category details
- link category buttons to new routes
- support category type in breadcrumbs
- add page to show items in `/product/[type]/[category]`
- update JSON-LD breadcrumbs for products

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b84a3cf588328a207a4b14ff7a194