### PR TITLE
feat: add global header and product routing

### DIFF
--- a/app/(landing)/page.tsx
+++ b/app/(landing)/page.tsx
@@ -1,4 +1,3 @@
-import { Header } from "@/components/navigation/Header";
 import { HeroSection } from "@/app/components/HeroSection";
 import { ServicesSection } from "@/app/components/ServicesSection";
 import { ProjectsSlider } from "@/app/components/ProjectsSlider";
@@ -10,8 +9,6 @@ import { ProductIntroSection } from "../components/ProductIntroSection";
 export default function Home() {
   return (
     <main className="flex flex-col min-h-screen">
-      {/* 固定ヘッダー */}
-      <Header />
       {/* ヒーローセクション */}
       <HeroSection />
       {/* サービス紹介 */}

--- a/app/blog/layout.tsx
+++ b/app/blog/layout.tsx
@@ -15,7 +15,7 @@ export default function RootLayout({
   return (
     <div>
       <HeaderBlog />
-      <main className="mt-[130px]">{children}</main>
+      <main className="mt-6">{children}</main>
       <Footer />
     </div>
   );

--- a/app/components/CategoryButton.tsx
+++ b/app/components/CategoryButton.tsx
@@ -2,7 +2,13 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
-export function CategoryButton({ label }: { label: string }) {
+export function CategoryButton({
+  label,
+  type,
+}: {
+  label: string;
+  type: "tool" | "template";
+}) {
   return (
     <Button
       asChild
@@ -10,7 +16,7 @@ export function CategoryButton({ label }: { label: string }) {
       size="sm"
       className="bg-white text-zinc-800 hover:bg-zinc-100 shadow"
     >
-      <Link href={`/product/category/${encodeURIComponent(label)}`}>{label}</Link>
+      <Link href={`/products/${type}/${encodeURIComponent(label)}`}>{label}</Link>
     </Button>
   );
 }

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -40,6 +40,12 @@ export function Header() {
               height={40}
               priority
             />
+            {pathname.startsWith("/blog") && (
+              <span className="text-blue-600">- Blog</span>
+            )}
+            {pathname.startsWith("/products") && (
+              <span className="text-blue-600">- Products</span>
+            )}
           </Link>
 
           {/* Desktopメニュー */}
@@ -74,14 +80,14 @@ export function Header() {
               </NavigationMenuItem>
               <NavigationMenuItem>
                 <Link
-                  href="/product"
+                  href="/products"
                   className={
-                    pathname.startsWith("/product")
+                    pathname.startsWith("/products")
                       ? "text-blue-600"
                       : "hover:underline"
                   }
                 >
-                  Product
+                  Products
                 </Link>
               </NavigationMenuItem>
               {/* <NavigationMenuItem>
@@ -136,13 +142,13 @@ export function Header() {
             </li>
             <li>
               <Link
-                href="/product"
+                href="/products"
                 onClick={() => setMenuOpen(false)}
                 className={
-                  pathname.startsWith("/product") ? "text-blue-600" : ""
+                  pathname.startsWith("/products") ? "text-blue-600" : ""
                 }
               >
-                Product
+                Products
               </Link>
             </li>
           </ul>

--- a/app/components/HeaderBlog.tsx
+++ b/app/components/HeaderBlog.tsx
@@ -1,138 +1,23 @@
 "use client";
-import { useEffect, useState } from "react";
-import { usePathname } from "next/navigation";
-import {
-  NavigationMenu,
-  NavigationMenuItem,
-  NavigationMenuList,
-} from "@/components/ui/navigation-menu";
 import Link from "next/link";
-import SimproSvg from "@/public/Simplo_gray_main_sub.svg";
-import Image from "next/image";
-import { Menu, X } from "lucide-react";
 
 const categories = ["Skill", "Book", "Job", "Life", "Design"];
 
 export function HeaderBlog() {
-  const [hideHeader, setHideHeader] = useState(false);
-  const [lastScrollY, setLastScrollY] = useState(0);
-  const [menuOpen, setMenuOpen] = useState(false);
-  const pathname = usePathname();
-
-  useEffect(() => {
-    const handleScroll = () => {
-      const currentY = window.scrollY;
-      setHideHeader(currentY > lastScrollY && currentY > 80);
-      setLastScrollY(currentY);
-    };
-    window.addEventListener("scroll", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, [lastScrollY]);
-
   return (
-    <header
-      className={`fixed top-0 left-0 w-full z-50 transition-transform duration-300 ${
-        hideHeader ? "-translate-y-full" : "translate-y-0"
-      }`}
-    >
-      {/* 上段: 白背景（ロゴ + メニュー） */}
-      <div className="border-b bg-white shadow-sm">
-        <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-3">
-          <div className="flex items-center gap-2">
-            <Link href="/" className="flex items-center gap-2 text-lg font-bold">
-              <Image
-                src={SimproSvg}
-                alt="Simpro Logo"
-                width={100}
-                height={40}
-                priority
-              />
-            </Link>
-            <span className="text-blue-600 text-lg">- Blog</span>
-          </div>
-
-          {/* Desktopメニュー */}
-          <NavigationMenu className="hidden md:block">
-            <NavigationMenuList className="space-x-6 text-sm font-medium">
-              <NavigationMenuItem>
-                <Link
-                  href="#top"
-                  className={
-                    pathname.startsWith("/blog") ? "text-blue-600" : "hover:underline"
-                  }
-                >
-                  TOP
-                </Link>
-              </NavigationMenuItem>
-              <NavigationMenuItem>
-                <Link href="#category" className="hover:underline">
-                  カテゴリ
-                </Link>
-              </NavigationMenuItem>
-              <NavigationMenuItem>
-                <Link href="#login" className="hover:underline">
-                  ログイン
-                </Link>
-              </NavigationMenuItem>
-            </NavigationMenuList>
-          </NavigationMenu>
-
-          {/* モバイルメニュー */}
-          <div className="md:hidden">
-            <button
-              onClick={() => setMenuOpen(!menuOpen)}
-              className="transition-transform duration-200"
+    <nav className="sticky top-16 z-40 bg-neutral-800 py-3">
+      <ul className="flex justify-center gap-8">
+        {categories.map((category) => (
+          <li key={category}>
+            <Link
+              href={`/blog/category/${category}`}
+              className="text-white text-lg tracking-wide hover:underline transition"
             >
-              {menuOpen ? <X size={24} /> : <Menu size={24} />}
-            </button>
-          </div>
-        </div>
-
-        {/* モバイルメニュー表示部 */}
-        <div
-          className={`md:hidden overflow-hidden transition-all duration-300 ease-in-out ${
-            menuOpen ? "max-h-60 opacity-100 py-4" : "max-h-0 opacity-0 py-0"
-          } bg-white px-6`}
-        >
-          <ul className="space-y-4 text-base">
-            <li>
-              <Link
-                href="#top"
-                onClick={() => setMenuOpen(false)}
-                className={pathname.startsWith("/blog") ? "text-blue-600" : ""}
-              >
-                TOP
-              </Link>
-            </li>
-            <li>
-              <Link href="#category" onClick={() => setMenuOpen(false)}>
-                カテゴリ
-              </Link>
-            </li>
-            <li>
-              <Link href="#login" onClick={() => setMenuOpen(false)}>
-                ログイン
-              </Link>
-            </li>
-          </ul>
-        </div>
-      </div>
-
-      {/* 下段: 黒背景のカテゴリバー */}
-      <nav className="bg-neutral-800 py-3">
-        <ul className="flex justify-center gap-8">
-          {categories.map((category) => (
-            <li key={category}>
-              <Link
-                href={`/blog/category/${category}`}
-                className="text-white text-lg tracking-wide hover:underline transition"
-              >
-                {category}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </nav>
-    </header>
+              {category}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
   );
 }

--- a/app/components/HeaderProduct.tsx
+++ b/app/components/HeaderProduct.tsx
@@ -1,9 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
-import { usePathname } from "next/navigation";
-import Link from "next/link";
-import Image from "next/image";
-import SimproSvg from "@/public/Simplo_gray_main_sub.svg";
+import { useState } from "react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { CategoryButton } from "./CategoryButton";
 
@@ -11,89 +7,46 @@ const toolCategories = ["Webツール", "GAS", "Excel VBA", "Executable File"];
 const templateCategories = ["Webサイトテンプレート", "Webアプリテンプレート"];
 
 export function HeaderProduct() {
-  const [hideHeader, setHideHeader] = useState(false);
   const [activeTab, setActiveTab] = useState("tool");
-  const pathname = usePathname();
-
-  useEffect(() => {
-    const handleScroll = () => {
-      const currentY = window.scrollY;
-      setHideHeader(currentY > 80);
-    };
-    window.addEventListener("scroll", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
 
   return (
-    <header
-      className={`fixed top-0 left-0 w-full z-50 transition-transform duration-300 ${hideHeader ? "-translate-y-full" : "translate-y-0"}`}
-    >
-      <div className="border-b bg-white shadow-sm">
-        <div className="max-w-7xl mx-auto flex justify-between items-center px-4 py-3">
-          <Link href="/" className="flex items-center gap-2 text-lg font-bold">
-            <Image src={SimproSvg} alt="Simpro Logo" width={100} height={40} priority />
-            <span className="text-blue-600">- Products</span>
-          </Link>
-          <div className="flex-1 mx-4 hidden md:block" />
-          <nav className="flex gap-6 text-sm font-medium">
-            <Link
-              href="/"
-              className={pathname === "/" ? "text-blue-600" : "hover:underline"}
-            >
-              TOP
-            </Link>
-            <Link href="#category" className="hover:underline">
-              カテゴリ
-            </Link>
-            <Link
-              href="/login"
-              className={
-                pathname.startsWith("/login") ? "text-blue-600" : "hover:underline"
-              }
-            >
-              ログイン
-            </Link>
-          </nav>
-        </div>
-        <div className="bg-zinc-800 text-white">
-          <div className="max-w-7xl mx-auto px-4 py-3">
-            <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-start gap-4 w-full">
-                <TabsList className="flex gap-2">
-                  <TabsTrigger
-                    value="tool"
-                    className="capitalize data-[state=active]:text-blue-600 data-[state=active]:font-bold"
-                  >
-                    tool
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="template"
-                    className="capitalize data-[state=active]:text-blue-600 data-[state=active]:font-bold"
-                  >
-                    template
-                  </TabsTrigger>
-                </TabsList>
-                <div className="flex-1 sm:ml-6">
-                  <TabsContent value="tool" className="sm:mt-0 mt-2">
-                    <div className="flex flex-wrap gap-3">
-                      {toolCategories.map((c) => (
-                        <CategoryButton key={c} label={c} />
-                      ))}
-                    </div>
-                  </TabsContent>
-                  <TabsContent value="template" className="sm:mt-0 mt-2">
-                    <div className="flex flex-wrap gap-3">
-                      {templateCategories.map((c) => (
-                        <CategoryButton key={c} label={c} />
-                      ))}
-                    </div>
-                  </TabsContent>
+    <div className="sticky top-16 z-40 bg-zinc-800 text-white">
+      <div className="max-w-7xl mx-auto px-4 py-3">
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-start gap-4 w-full">
+            <TabsList className="flex gap-2">
+              <TabsTrigger
+                value="tool"
+                className="capitalize data-[state=active]:text-blue-600 data-[state=active]:font-bold"
+              >
+                tool
+              </TabsTrigger>
+              <TabsTrigger
+                value="template"
+                className="capitalize data-[state=active]:text-blue-600 data-[state=active]:font-bold"
+              >
+                template
+              </TabsTrigger>
+            </TabsList>
+            <div className="flex-1 sm:ml-6">
+              <TabsContent value="tool" className="sm:mt-0 mt-2">
+                <div className="flex flex-wrap gap-3">
+                  {toolCategories.map((c) => (
+                    <CategoryButton key={c} label={c} type="tool" />
+                  ))}
                 </div>
-              </div>
-            </Tabs>
+              </TabsContent>
+              <TabsContent value="template" className="sm:mt-0 mt-2">
+                <div className="flex flex-wrap gap-3">
+                  {templateCategories.map((c) => (
+                    <CategoryButton key={c} label={c} type="template" />
+                  ))}
+                </div>
+              </TabsContent>
+            </div>
           </div>
-        </div>
+        </Tabs>
       </div>
-    </header>
+    </div>
   );
 }

--- a/app/components/ProductIntroSection.tsx
+++ b/app/components/ProductIntroSection.tsx
@@ -112,7 +112,7 @@ export function ProductIntroSection() {
               transition={{ duration: 1.6, ease: "easeOut" }}
               viewport={{ once: true }}
             >
-              <Link href={`/product/${tool.slug}`}>
+              <Link href={`/products`}>
                 <div className="w-full h-40 relative">
                   <Image
                     src={tool.image}
@@ -137,7 +137,7 @@ export function ProductIntroSection() {
 
         {/* CTA */}
         <Link
-          href="/product"
+          href="/products"
           className="inline-block mt-6 bg-green-600 text-white px-6 py-2 rounded-xl font-medium hover:bg-green-700 transition"
         >
           プロダクト一覧を見る

--- a/app/components/ToolIntroSection.tsx
+++ b/app/components/ToolIntroSection.tsx
@@ -112,7 +112,7 @@ export function ToolIntroSection() {
               transition={{ duration: 1.6, ease: "easeOut" }}
               viewport={{ once: true }}
             >
-              <Link href={`/product/${tool.slug}`}>
+              <Link href={`/products`}>
                 <div className="w-full h-40 relative">
                   <Image
                     src={tool.image}
@@ -137,7 +137,7 @@ export function ToolIntroSection() {
 
         {/* CTA */}
         <Link
-          href="/product"
+          href="/products"
           className="inline-block mt-6 bg-green-600 text-white px-6 py-2 rounded-xl font-medium hover:bg-green-700 transition"
         >
           プロダクト一覧を見る

--- a/app/components/product/ProductBreadcrumbs.tsx
+++ b/app/components/product/ProductBreadcrumbs.tsx
@@ -22,13 +22,13 @@ type Crumb = {
 export function ProductBreadcrumbs({ category, title }: BreadcrumbsProps) {
   const items: Crumb[] = [
     { name: "Home", href: "/" },
-    { name: "Products", href: "/product" },
+    { name: "Products", href: "/products" },
   ];
 
   if (category) {
     items.push({
       name: category,
-      href: `/product/category/${encodeURIComponent(category)}`,
+      href: `/products/category/${encodeURIComponent(category)}`,
     });
   }
 

--- a/app/components/product/ProductCard.tsx
+++ b/app/components/product/ProductCard.tsx
@@ -7,7 +7,7 @@ import { tagColors } from "@/lib/utils/tag_color";
 export function ProductCard({ tool }: { tool: Product }) {
   return (
     <div className="rounded-xl shadow bg-white overflow-hidden hover:shadow-md transition">
-      <Link href={`/product/${tool.slug}`}>
+      <Link href={`/products/${tool.slug}`}>
         <Image
           src={tool.imageUrl}
           alt={tool.title}
@@ -18,7 +18,7 @@ export function ProductCard({ tool }: { tool: Product }) {
       </Link>
       <div className="p-4 space-y-2">
         <Link
-          href={`/product/${tool.slug}`}
+          href={`/products/${tool.slug}`}
           className="text-lg font-semibold hover:underline block"
         >
           {tool.title}（{tool.category}）
@@ -42,7 +42,7 @@ export function ProductCard({ tool }: { tool: Product }) {
         </div>
         <div className="flex justify-between items-center mt-2">
           <Link
-          href={`/product/${tool.slug}`}
+            href={`/products/${tool.slug}`}
             className="text-sm text-blue-600 hover:underline"
           >
             詳細はこちら

--- a/app/components/product/ProductForm.tsx
+++ b/app/components/product/ProductForm.tsx
@@ -129,7 +129,7 @@ export function ProductForm({ defaultValues, id }: Props) {
 
     setLoading(false);
     if (res.ok) {
-      router.push("/product");
+      router.push("/products");
     } else {
       alert("送信に失敗しました");
     }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Header } from "./components/Header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,9 +26,10 @@ export default function RootLayout({
   return (
     <html lang="jp">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased pt-16`}
       >
-        {children}{" "}
+        <Header />
+        {children}
       </body>
     </html>
   );

--- a/app/products/[slug]/page.tsx
+++ b/app/products/[slug]/page.tsx
@@ -24,8 +24,8 @@ export default async function ProductDetailPage({
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? "";
   const breadcrumbItems = [
     { name: "Home", url: `${baseUrl}/` },
-    { name: "Products", url: `${baseUrl}/product` },
-    { name: product.category, url: `${baseUrl}/product/category/${encodeURIComponent(product.category)}` },
+    { name: "Products", url: `${baseUrl}/products` },
+    { name: product.category, url: `${baseUrl}/products/category/${encodeURIComponent(product.category)}` },
     { name: product.title },
   ];
   const jsonLd = generateBreadcrumbJsonLd(breadcrumbItems);

--- a/app/products/[type]/[category]/[slug]/page.tsx
+++ b/app/products/[type]/[category]/[slug]/page.tsx
@@ -1,0 +1,22 @@
+import { notFound } from "next/navigation";
+import { productDummy } from "@/data/products_dummy";
+
+export default function ProductDetailPage({
+  params,
+}: {
+  params: { type: string; category: string; slug: string };
+}) {
+  const { type, category, slug } = params;
+  const decoded = decodeURIComponent(category);
+  const item = productDummy[type]?.[decoded]?.find((p) => p.slug === slug);
+  if (!item) {
+    notFound();
+  }
+
+  return (
+    <div className="px-4 py-8">
+      <h1 className="text-3xl font-bold mb-4">{item.title}</h1>
+      <p className="text-gray-700">{item.description}</p>
+    </div>
+  );
+}

--- a/app/products/[type]/[category]/page.tsx
+++ b/app/products/[type]/[category]/page.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { productDummy } from "@/data/products_dummy";
+
+export default function ProductCategoryPage({
+  params,
+}: {
+  params: { type: string; category: string };
+}) {
+  const { type, category } = params;
+  const decoded = decodeURIComponent(category);
+  const items = productDummy[type]?.[decoded];
+  if (!items) {
+    notFound();
+  }
+
+  return (
+    <section className="px-4 py-8">
+      <h1 className="text-2xl font-bold mb-4">{decoded}</h1>
+      <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {items.map((item) => (
+          <li key={item.slug} className="border rounded-md p-4 shadow-sm">
+            <h2 className="text-lg font-semibold mb-2">{item.title}</h2>
+            <p className="text-sm text-gray-600 mb-2">{item.description}</p>
+            <Link
+              href={`/products/${type}/${encodeURIComponent(decoded)}/${item.slug}`}
+              className="text-blue-600 hover:underline"
+            >
+              詳細を見る
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/app/products/layout.tsx
+++ b/app/products/layout.tsx
@@ -11,7 +11,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <div className="flex flex-col min-h-screen">
       <HeaderProduct />
-      <main className="flex-grow mt-[130px]">{children}</main>
+      <main className="flex-grow mt-6">{children}</main>
       <Footer />
     </div>
   );

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -11,7 +11,7 @@ export default async function ProductsPage() {
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? "";
   const breadcrumbItems = [
     { name: "Home", url: `${baseUrl}/` },
-    { name: "Products", url: `${baseUrl}/product` },
+    { name: "Products", url: `${baseUrl}/products` },
   ];
   const jsonLd = generateBreadcrumbJsonLd(breadcrumbItems);
 
@@ -24,7 +24,7 @@ export default async function ProductsPage() {
       <ProductBreadcrumbs />
       <div className="flex items-center justify-between py-4 mt-8">
         <h1 className="text-2xl text-gray-800">プロダクト一覧</h1>
-        <Link href="/product/new">
+        <Link href="/products/new">
           <Button size="sm" className="bg-blue-600 text-white hover:bg-blue-700">
             新規登録
           </Button>

--- a/data/products_dummy.ts
+++ b/data/products_dummy.ts
@@ -1,0 +1,59 @@
+export type ProductItem = {
+  slug: string;
+  title: string;
+  description: string;
+};
+
+export const productDummy: Record<string, Record<string, ProductItem[]>> = {
+  tool: {
+    "Webツール": [
+      {
+        slug: "tool-1",
+        title: "Tool 1",
+        description: "Webツールのダミー1",
+      },
+      {
+        slug: "tool-2",
+        title: "Tool 2",
+        description: "Webツールのダミー2",
+      },
+    ],
+    GAS: [
+      {
+        slug: "gas-1",
+        title: "GAS Script",
+        description: "GASスクリプトのダミー",
+      },
+    ],
+    "Excel VBA": [
+      {
+        slug: "vba-1",
+        title: "VBA Macro",
+        description: "Excel VBAのダミー",
+      },
+    ],
+    "Executable File": [
+      {
+        slug: "exe-1",
+        title: "Executable Utility",
+        description: "実行ファイルのダミー",
+      },
+    ],
+  },
+  template: {
+    "Webサイトテンプレート": [
+      {
+        slug: "site-1",
+        title: "Website Template",
+        description: "Webサイトテンプレートのダミー",
+      },
+    ],
+    "Webアプリテンプレート": [
+      {
+        slug: "app-1",
+        title: "App Template",
+        description: "Webアプリテンプレートのダミー",
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Summary
- add global `Header` and show page context after logo
- align blog and product headers under global bar
- build dummy data product routes for category and detail pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d6d6272ac8328bee2265b032392a3