### PR TITLE
fix dynamic slug conflicts in Next.js routes

### DIFF
--- a/app/blog/[blogSlug]/page.tsx
+++ b/app/blog/[blogSlug]/page.tsx
@@ -8,12 +8,16 @@ import { CalendarIcon, UserCircleIcon } from "lucide-react";
 import { BlockObjectResponse } from "@notionhq/client";
 import Script from "next/script";
 
-export default async function BlogDetailPage({ params }: { params: Promise<{ slug: string }> | { slug: string } }) {
-  const { slug: raw } = await params;
-  const slug = decodeURIComponent(raw);
+export default async function BlogDetailPage({
+  params,
+}: {
+  params: Promise<{ blogSlug: string }> | { blogSlug: string };
+}) {
+  const { blogSlug: raw } = await params;
+  const blogSlug = decodeURIComponent(raw);
 
   const posts = await getPublishedArticles();
-  const post = posts.find((p) => p.title === slug);
+  const post = posts.find((p) => p.title === blogSlug);
 
   if (!post) throw new Error("システムエラーです。");
 

--- a/app/components/CategoryButton.tsx
+++ b/app/components/CategoryButton.tsx
@@ -16,7 +16,7 @@ export function CategoryButton({
       size="sm"
       className="bg-white text-zinc-800 hover:bg-zinc-100 shadow"
     >
-      <Link href={`/products/${type}/${encodeURIComponent(label)}`}>{label}</Link>
+      <Link href={`/products/categories/${type}/${encodeURIComponent(label)}`}>{label}</Link>
     </Button>
   );
 }

--- a/app/components/product/ProductBreadcrumbs.tsx
+++ b/app/components/product/ProductBreadcrumbs.tsx
@@ -28,7 +28,6 @@ export function ProductBreadcrumbs({ category, title }: BreadcrumbsProps) {
   if (category) {
     items.push({
       name: category,
-      href: `/products/category/${encodeURIComponent(category)}`,
     });
   }
 

--- a/app/products/[productSlug]/edit/page.tsx
+++ b/app/products/[productSlug]/edit/page.tsx
@@ -5,10 +5,10 @@ import { fetchProductById } from "@/lib/supabase";
 export default async function EditProductPage({
   params,
 }: {
-  params: Promise<{ slug: string }> | { slug: string };
+  params: Promise<{ productSlug: string }> | { productSlug: string };
 }) {
-  const { slug } = await params;
-  const id = Number(slug);
+  const { productSlug } = await params;
+  const id = Number(productSlug);
   const content = await fetchProductById(id);
 
   if (!content || content.type !== "TOOL") {

--- a/app/products/[productSlug]/page.tsx
+++ b/app/products/[productSlug]/page.tsx
@@ -11,11 +11,11 @@ import { notFound } from "next/navigation";
 export default async function ProductDetailPage({
   params,
 }: {
-  params: Promise<{ slug: string }> | { slug: string };
+  params: Promise<{ productSlug: string }> | { productSlug: string };
 }) {
-  const { slug: raw } = await params;
-  const slug = decodeURIComponent(raw);
-  const product = await getProductBySlug(slug);
+  const { productSlug: raw } = await params;
+  const productSlug = decodeURIComponent(raw);
+  const product = await getProductBySlug(productSlug);
 
   if (!product) {
     notFound();
@@ -25,7 +25,7 @@ export default async function ProductDetailPage({
   const breadcrumbItems = [
     { name: "Home", url: `${baseUrl}/` },
     { name: "Products", url: `${baseUrl}/products` },
-    { name: product.category, url: `${baseUrl}/products/category/${encodeURIComponent(product.category)}` },
+    { name: product.category },
     { name: product.title },
   ];
   const jsonLd = generateBreadcrumbJsonLd(breadcrumbItems);

--- a/app/products/categories/[productType]/[productCategory]/[itemSlug]/page.tsx
+++ b/app/products/categories/[productType]/[productCategory]/[itemSlug]/page.tsx
@@ -4,11 +4,11 @@ import { productDummy } from "@/data/products_dummy";
 export default function ProductDetailPage({
   params,
 }: {
-  params: { type: string; category: string; slug: string };
+  params: { productType: string; productCategory: string; itemSlug: string };
 }) {
-  const { type, category, slug } = params;
-  const decoded = decodeURIComponent(category);
-  const item = productDummy[type]?.[decoded]?.find((p) => p.slug === slug);
+  const { productType, productCategory, itemSlug } = params;
+  const decoded = decodeURIComponent(productCategory);
+  const item = productDummy[productType]?.[decoded]?.find((p) => p.slug === itemSlug);
   if (!item) {
     notFound();
   }

--- a/app/products/categories/[productType]/[productCategory]/page.tsx
+++ b/app/products/categories/[productType]/[productCategory]/page.tsx
@@ -5,11 +5,11 @@ import { productDummy } from "@/data/products_dummy";
 export default function ProductCategoryPage({
   params,
 }: {
-  params: { type: string; category: string };
+  params: { productType: string; productCategory: string };
 }) {
-  const { type, category } = params;
-  const decoded = decodeURIComponent(category);
-  const items = productDummy[type]?.[decoded];
+  const { productType, productCategory } = params;
+  const decoded = decodeURIComponent(productCategory);
+  const items = productDummy[productType]?.[decoded];
   if (!items) {
     notFound();
   }
@@ -23,7 +23,7 @@ export default function ProductCategoryPage({
             <h2 className="text-lg font-semibold mb-2">{item.title}</h2>
             <p className="text-sm text-gray-600 mb-2">{item.description}</p>
             <Link
-              href={`/products/${type}/${encodeURIComponent(decoded)}/${item.slug}`}
+              href={`/products/categories/${productType}/${encodeURIComponent(decoded)}/${item.slug}`}
               className="text-blue-600 hover:underline"
             >
               詳細を見る

--- a/components/products/CategoryTabs.tsx
+++ b/components/products/CategoryTabs.tsx
@@ -6,18 +6,18 @@ import { usePathname } from 'next/navigation'
 export function CategoryTabs() {
   const pathname = usePathname()
   const segments = pathname.split('/')
-  const type = segments[2] || 'tool'
+  const type = segments[3] || 'tool'
 
   return (
     <Tabs value={type} className="mb-4">
       <TabsList className="justify-start gap-2">
         <TabsTrigger value="tool" asChild>
-          <Link href="/products/tool/webtool" className="capitalize">
+          <Link href="/products/categories/tool/webtool" className="capitalize">
             tool
           </Link>
         </TabsTrigger>
         <TabsTrigger value="template" asChild>
-          <Link href="/products/template/web" className="capitalize">
+          <Link href="/products/categories/template/web" className="capitalize">
             template
           </Link>
         </TabsTrigger>

--- a/components/products/SubCategoryTags.tsx
+++ b/components/products/SubCategoryTags.tsx
@@ -9,7 +9,7 @@ const templateCategories = ['web', 'app']
 export function SubCategoryTags({ type }: { type: string }) {
   const pathname = usePathname()
   const segments = pathname.split('/')
-  const current = segments[3] || ''
+  const current = segments[4] || ''
   const categories = type === 'template' ? templateCategories : toolCategories
 
   return (
@@ -24,7 +24,7 @@ export function SubCategoryTags({ type }: { type: string }) {
             size="sm"
             className={active ? 'bg-blue-600 text-white border-blue-600' : ''}
           >
-            <Link href={`/products/${type}/${c}`}>{c}</Link>
+            <Link href={`/products/categories/${type}/${c}`}>{c}</Link>
           </Button>
         )
       })}

--- a/data/navigation.ts
+++ b/data/navigation.ts
@@ -23,8 +23,8 @@ export const navigation: NavItem[] = [
     title: 'Products',
     href: '/products',
     children: [
-      { title: 'Tool', href: '/products/tool/webtool' },
-      { title: 'Template', href: '/products/template/web' }
+      { title: 'Tool', href: '/products/categories/tool/webtool' },
+      { title: 'Template', href: '/products/categories/template/web' }
     ]
   }
 ]


### PR DESCRIPTION
## Summary
- use unique `blogSlug` param for blog details
- restructure product routes to avoid slug/type conflict
- update navigation and components for new product category paths

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_688d713046408328ad5df7cea77503a1