### PR TITLE
Align product and blog page spacing

### DIFF
--- a/app/components/HeaderProduct.tsx
+++ b/app/components/HeaderProduct.tsx
@@ -35,7 +35,6 @@ export function HeaderProduct() {
     router.push(`/${activeTab}/${encodeURIComponent(label)}`);
   };
 
-  const categories = activeTab === "tool" ? toolCategories : templateCategories;
 
   return (
     <div

--- a/app/products/categories/[productType]/[productCategory]/[itemSlug]/page.tsx
+++ b/app/products/categories/[productType]/[productCategory]/[itemSlug]/page.tsx
@@ -14,7 +14,7 @@ export default function ProductDetailPage({
   }
 
   return (
-    <div className="px-4 py-8">
+    <div className="px-20 py-4 mt-8">
       <h1 className="text-3xl font-bold mb-4">{item.title}</h1>
       <p className="text-gray-700">{item.description}</p>
     </div>

--- a/app/products/categories/[productType]/[productCategory]/page.tsx
+++ b/app/products/categories/[productType]/[productCategory]/page.tsx
@@ -15,22 +15,24 @@ export default function ProductCategoryPage({
   }
 
   return (
-    <section className="px-4 py-8">
-      <h1 className="text-2xl font-bold mb-4">{decoded}</h1>
-      <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {items.map((item) => (
-          <li key={item.slug} className="border rounded-md p-4 shadow-sm">
-            <h2 className="text-lg font-semibold mb-2">{item.title}</h2>
-            <p className="text-sm text-gray-600 mb-2">{item.description}</p>
-            <Link
-              href={`/products/categories/${productType}/${encodeURIComponent(decoded)}/${item.slug}`}
-              className="text-blue-600 hover:underline"
-            >
-              詳細を見る
-            </Link>
-          </li>
-        ))}
-      </ul>
+    <section className="px-4 sm:px-8 md:px-16 lg:px-20 py-4 mt-8">
+      <h1 className="py-4 mt-4 text-2xl font-bold">{decoded}</h1>
+      <div className="py-2">
+        <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {items.map((item) => (
+            <li key={item.slug} className="border rounded-md p-4 shadow-sm">
+              <h2 className="text-lg font-semibold mb-2">{item.title}</h2>
+              <p className="text-sm text-gray-600 mb-2">{item.description}</p>
+              <Link
+                href={`/products/categories/${productType}/${encodeURIComponent(decoded)}/${item.slug}`}
+                className="text-blue-600 hover:underline"
+              >
+                詳細を見る
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
     </section>
   );
 }

--- a/app/products/new/page.tsx
+++ b/app/products/new/page.tsx
@@ -2,8 +2,8 @@ import { ProductForm } from "@/app/components/product/ProductForm";
 
 export default function NewProductPage() {
   return (
-    <section className="p-4">
-      <h1 className="text-xl font-bold mb-4">プロダクト登録</h1>
+    <section className="px-4 sm:px-8 md:px-16 lg:px-20 py-4 mt-8">
+      <h1 className="py-4 mt-4 text-xl font-bold">プロダクト登録</h1>
       <ProductForm />
     </section>
   );


### PR DESCRIPTION
## Summary
- harmonize margins/padding on product category, item detail, and new product pages with blog page layout
- drop unused variable from HeaderProduct to satisfy lint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d8ec1fec88328b68aa16d7d7e554a